### PR TITLE
Move effects from signals into handler functions

### DIFF
--- a/src/Halogen.purs
+++ b/src/Halogen.purs
@@ -1,5 +1,4 @@
-module Halogen 
-   where
+module Halogen where
     
 import DOM
 
@@ -11,6 +10,9 @@ import Control.Monad.Eff.Ref
 import Halogen.HTML (HTML(), renderHtml)
 import Halogen.Signal 
 import Halogen.VirtualDOM   
+ 
+-- | Wraps the effects required by the `runUI` and `runUIEff` functions.
+type Heff eff = Eff (ref :: Ref, dom :: DOM | eff)
  
 -- | `runUI` takes a UI represented as a signal function, and renders it to the DOM
 -- | using `virtual-dom`.
@@ -26,33 +28,53 @@ import Halogen.VirtualDOM
 -- |
 -- | ```purescript
 -- | ui :: forall eff. Signal1 eff Unit (HTML Unit)
--- | ui = view <$> stateful 0 (\n _ -> pure (n + 1))
+-- | ui = view <$> stateful 0 (\n _ -> n + 1)
 -- |   where
 -- |   view :: Number -> HTML Unit
 -- |   view n = button [ OnClick (const unit) ] [ text (show n) ]
 -- | ```
-runUI :: forall i eff. Signal1 (ref :: Ref, dom :: DOM | eff) i (HTML i) -> Eff (ref :: Ref, dom :: DOM | eff) Node
-runUI signal = do
+-- |
+runUI :: forall i eff. Signal1 i (HTML i) -> Heff eff Node
+runUI signal = runUIEff signal (\i k -> k i)
+
+-- | `runUIEff` is a more general version of `runUI` which can be used to construct other
+-- | top-level handlers for applications.
+-- |
+-- | `runUIEff` takes a signal function which creates HTML documents containing _requests_, 
+-- | and a handler function which accepts requests and provides new inputs to a continuation as they
+-- | become available.
+-- |
+-- | For example, the handler function might be responsible for issuing AJAX requests on behalf of the
+-- | application.
+-- |
+-- | In this way, all effects are pushed to the handler function at the boundary of the application.
+-- |
+runUIEff :: forall i r eff. Signal1 i (HTML r) -> (r -> (i -> Heff eff Unit) -> Heff eff Unit) -> Heff eff Node
+runUIEff signal handler = do
   ref <- newRef Nothing
   runUI' ref
+  
   where
-  runUI' :: forall i. RefVal _ -> Eff (ref :: Ref, dom :: DOM | eff) Node
+  runUI' :: forall i. RefVal _ -> Heff eff Node
   runUI' ref = do
     let html  = head signal
         next  = tail signal
-        vtree = renderHtml inputHandler html
+        vtree = renderHtml requestHandler html
         node  = createElement vtree  
     writeRef ref $ Just { signal: next, vtree: vtree, node: node }
     return node    
+    
     where
-    inputHandler :: i -> Eff (ref :: Ref, dom :: DOM | eff) Unit
+    requestHandler :: r -> Heff eff Unit
+    requestHandler r = handler r inputHandler
+    
+    inputHandler :: i -> Heff eff Unit
     inputHandler i = do
       Just { signal: signal, vtree: vtree, node: node } <- readRef ref
-      next <- runSignal signal i
+      let next = runSignal signal i
       let html    = head next
           signal' = tail next
-          vtree'  = renderHtml inputHandler html
+          vtree'  = renderHtml requestHandler html
           diffs   = diff vtree vtree' 
       node' <- patch diffs node
       writeRef ref $ Just { signal: signal', vtree: vtree', node: node' }
-      

--- a/src/Halogen/Signal.purs
+++ b/src/Halogen/Signal.purs
@@ -13,82 +13,79 @@ module Halogen.Signal
   , head
   , tail
   ) where
-      
-import Data.Profunctor
-
-import Control.Apply (lift2)
-import Control.Monad.Eff
+    
+import Data.Profunctor    
     
 -- | A `Signal` represents a state machine which responds to inputs of type `i`, producing outputs of type `o`.
-newtype Signal eff i o = Signal (i -> Eff eff (Signal1 eff i o))
+newtype Signal i o = Signal (i -> Signal1 i o)
     
 -- | Run a `Signal` by providing an input
-runSignal :: forall i o eff. Signal eff i o -> i -> Eff eff (Signal1 eff i o)
+runSignal :: forall i o. Signal i o -> i -> Signal1 i o
 runSignal (Signal k) = k
     
 -- | `Signal1` represents non-empty signals, i.e. signals with an initial output value.
-newtype Signal1 eff i o = Signal1 { result :: o, next :: Signal eff i o }
+newtype Signal1 i o = Signal1 { result :: o, next :: Signal i o }
 
 -- | Run a `Signal1` to obtain the initial value and remaining signal
-runSignal1 :: forall eff i o. Signal1 eff i o -> { result :: o, next :: Signal eff i o }
+runSignal1 :: forall i o. Signal1 i o -> { result :: o, next :: Signal i o }
 runSignal1 (Signal1 o) = o
   
 -- | A `Signal` which returns the latest input
-input :: forall eff i. Signal eff i i
-input = Signal \i -> return $ Signal1 { result: i, next: input } 
+input :: forall i. Signal i i
+input = Signal \i -> Signal1 { result: i, next: input } 
 
 -- | Convert a `Signal` to a `Signal1` by providing an initial value
-startingAt :: forall eff i o. Signal eff i o -> o -> Signal1 eff i o
+startingAt :: forall i o. Signal i o -> o -> Signal1 i o
 startingAt s o = Signal1 { result: o, next: s }
 
 -- | Get the current value of a `Signal1`
-head :: forall eff i o. Signal1 eff i o -> o
+head :: forall i o. Signal1 i o -> o
 head (Signal1 o) = o.result
 
 -- | Convert a `Signal1` to a `Signal` by ignoring its initial value
-tail :: forall eff i o. Signal1 eff i o -> Signal eff i o
+tail :: forall i o. Signal1 i o -> Signal i o
 tail (Signal1 o) = o.next
 
 -- | Creates a stateful `Signal`
-stateful :: forall eff s i o. s -> (s -> i -> Eff eff s) -> Signal1 eff i s
+stateful :: forall s i o. s -> (s -> i -> s) -> Signal1 i s
 stateful s step = go s
   where
-  go :: s -> Signal1 eff i s
-  go s = Signal1 { result: s, next: Signal \i -> go <$> step s i }
+  go :: s -> Signal1 i s
+  go s = Signal1 { result: s, next: Signal (go <<< step s) }
 
-instance functorSignal :: Functor (Signal eff i) where
-  (<$>) f (Signal k) = Signal \i -> (f <$>) <$> k i
+instance functorSignal :: Functor (Signal i) where
+  (<$>) f (Signal k) = Signal \i -> f <$> k i
 
-instance functorSignal1 :: Functor (Signal1 eff i) where
+instance functorSignal1 :: Functor (Signal1 i) where
   (<$>) f (Signal1 o) = Signal1 { result: f o.result, next: f <$> o.next }
 
-instance applySignal :: Apply (Signal eff i) where
-  (<*>) f x = Signal \i -> runSignal f i `lift2 (<*>)` runSignal x i
+instance applySignal :: Apply (Signal i) where
+  (<*>) f x = Signal \i -> runSignal f i <*> runSignal x i
 
-instance applySignal1 :: Apply (Signal1 eff i) where
+instance applySignal1 :: Apply (Signal1 i) where
   (<*>) (Signal1 f) (Signal1 x) = Signal1 { result: f.result x.result, next: f.next <*> x.next }
 
-instance applicativeSignal :: Applicative (Signal eff i) where
-  pure a = Signal \_ -> pure (pure a)
+instance applicativeSignal :: Applicative (Signal i) where
+  pure a = Signal \_ -> pure a
 
-instance applicativeSignal1 :: Applicative (Signal1 eff i) where
+instance applicativeSignal1 :: Applicative (Signal1 i) where
   pure a = Signal1 { result: a, next: pure a }
   
-instance profunctorSignal :: Profunctor (Signal eff) where
-  dimap f g (Signal k) = Signal \i -> dimap f g <$> k (f i)
+instance profunctorSignal :: Profunctor Signal where
+  dimap f g (Signal k) = Signal \i -> dimap f g (k (f i))
   
-instance profunctorSignal1 :: Profunctor (Signal1 eff) where
+instance profunctorSignal1 :: Profunctor Signal1 where
   dimap f g (Signal1 o) = Signal1 { result: g o.result, next: dimap f g o.next }
   
-instance semigroupoidSignal :: Semigroupoid (Signal eff) where
+instance semigroupoidSignal :: Semigroupoid Signal where
   (<<<) f g =
-    Signal \i -> do s1 <- runSignal g i
-                    s2 <- runSignal f (head s1)
-                    return (s2 <<< s1)
+    Signal \i -> let s1 = runSignal g i
+                     s2 = runSignal f (head s1)
+                 in s2 <<< s1
          
-instance semigroupoidSignal1 :: Semigroupoid (Signal1 eff) where
+instance semigroupoidSignal1 :: Semigroupoid Signal1 where
   (<<<) f g = Signal1 { result: head f, next: tail f <<< tail g }
 
-instance categorySignal :: Category (Signal eff) where
+instance categorySignal :: Category Signal where
   id = input
  

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -23,7 +23,7 @@ foreign import appendToBody
 
 data Input = Increment | Decrement
 
-ui :: forall eff. Signal1 (trace :: Trace | eff) Input (H.HTML Input)
+ui :: forall eff. Signal1 Input (H.HTML Input)
 ui = view <$> stateful 0 update
   where
   view :: Number -> H.HTML Input
@@ -35,13 +35,9 @@ ui = view <$> stateful 0 update
                          ]
                   ]
 
-  update :: Number -> Input -> Eff (trace :: Trace | eff) Number
-  update n Increment = do
-    trace "Increment"
-    return (n + 1)
-  update n Decrement = do
-    trace "Decrement"
-    return (n - 1)
+  update :: Number -> Input -> Number
+  update n Increment = n + 1
+  update n Decrement = n - 1
 
 main = do
   node <- runUI ui


### PR DESCRIPTION
@jdegoes @cryogenian This PR moves effects out of signal functions and into the top level _handler function_. I have also added `runUIEff` which can be used to build more general top-level loops.

I spent some time thinking about replacing signal functions with regular signals, but I came across some issues which I can discuss tomorrow.

John, I also had some issues with `Aff` which I can discuss separately, so this uses `Eff` for now.

What do you think?