### PR TITLE
Add EventHandlerT, fix #57

### DIFF
--- a/docs/Halogen-Bootstrap-Controls.md
+++ b/docs/Halogen-Bootstrap-Controls.md
@@ -17,7 +17,7 @@ A `CrumbTrail` is a zipper with a current location, and crumbs behind and in fro
 #### `breadcrumbs`
 
 ``` purescript
-breadcrumbs :: forall p i. CrumbTrail i -> H.HTML p i
+breadcrumbs :: forall m p i. (Applicative m) => CrumbTrail i -> H.HTML p (m i)
 ```
 
 Create a breadcrumb navigation element from an array of `Crumb`s.
@@ -121,7 +121,7 @@ A navbar configuration
 #### `navbar`
 
 ``` purescript
-navbar :: forall p i. NavBar i -> H.HTML p i
+navbar :: forall m p i. (Applicative m) => NavBar i -> H.HTML p (m i)
 ```
 
 Create a navbar from a configuration object.

--- a/docs/Halogen-Events.md
+++ b/docs/Halogen-Events.md
@@ -50,7 +50,7 @@ they may be safely embedded in HTML documents.
 #### `input`
 
 ``` purescript
-input :: forall i m a. (Applicative m) => (a -> i) -> a -> EventHandler (m i)
+input :: forall i m a. (Applicative m) => (a -> i) -> a -> EventHandlerT m i
 ```
 
 A helper function which can be used to create simple event handlers.
@@ -72,241 +72,249 @@ withEventHandlerT :: forall i m e. (e -> EventHandlerT m i) -> e -> EventHandler
 
 Create an event handler which uses `EventHandlerT`.
 
+#### `handlerT`
+
+``` purescript
+handlerT :: forall fields m i. H.EventName fields -> (Event fields -> EventHandlerT m i) -> H.Attr (m i)
+```
+
+Attach an event handler which uses `EventHandlerT`.
+
 #### `onabort`
 
 ``` purescript
-onabort :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onabort :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onbeforeunload`
 
 ``` purescript
-onbeforeunload :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onbeforeunload :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onerror`
 
 ``` purescript
-onerror :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onerror :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onhashchange`
 
 ``` purescript
-onhashchange :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onhashchange :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onload`
 
 ``` purescript
-onload :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onload :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onpageshow`
 
 ``` purescript
-onpageshow :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onpageshow :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onpagehide`
 
 ``` purescript
-onpagehide :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onpagehide :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onresize`
 
 ``` purescript
-onresize :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onresize :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onscroll`
 
 ``` purescript
-onscroll :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onscroll :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onunload`
 
 ``` purescript
-onunload :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onunload :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onchange`
 
 ``` purescript
-onchange :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onchange :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `oninput`
 
 ``` purescript
-oninput :: forall i. (Event () -> EventHandler i) -> H.Attr i
+oninput :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `oninvalid`
 
 ``` purescript
-oninvalid :: forall i. (Event () -> EventHandler i) -> H.Attr i
+oninvalid :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onreset`
 
 ``` purescript
-onreset :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onreset :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onsearch`
 
 ``` purescript
-onsearch :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onsearch :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onselect`
 
 ``` purescript
-onselect :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onselect :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onsubmit`
 
 ``` purescript
-onsubmit :: forall i. (Event () -> EventHandler i) -> H.Attr i
+onsubmit :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onclick`
 
 ``` purescript
-onclick :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
+onclick :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `oncontextmenu`
 
 ``` purescript
-oncontextmenu :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
+oncontextmenu :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `ondblclick`
 
 ``` purescript
-ondblclick :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
+ondblclick :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onmousedown`
 
 ``` purescript
-onmousedown :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
+onmousedown :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onmouseenter`
 
 ``` purescript
-onmouseenter :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
+onmouseenter :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onmouseleave`
 
 ``` purescript
-onmouseleave :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
+onmouseleave :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onmousemove`
 
 ``` purescript
-onmousemove :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
+onmousemove :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onmouseover`
 
 ``` purescript
-onmouseover :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
+onmouseover :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onmouseout`
 
 ``` purescript
-onmouseout :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
+onmouseout :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onmouseup`
 
 ``` purescript
-onmouseup :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
+onmouseup :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onkeydown`
 
 ``` purescript
-onkeydown :: forall i. (Event KeyboardEvent -> EventHandler i) -> H.Attr i
+onkeydown :: forall m i. (Event KeyboardEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onkeypress`
 
 ``` purescript
-onkeypress :: forall i. (Event KeyboardEvent -> EventHandler i) -> H.Attr i
+onkeypress :: forall m i. (Event KeyboardEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onkeyup`
 
 ``` purescript
-onkeyup :: forall i. (Event KeyboardEvent -> EventHandler i) -> H.Attr i
+onkeyup :: forall m i. (Event KeyboardEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onblur`
 
 ``` purescript
-onblur :: forall i. (Event FocusEvent -> EventHandler i) -> H.Attr i
+onblur :: forall m i. (Event FocusEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onfocus`
 
 ``` purescript
-onfocus :: forall i. (Event FocusEvent -> EventHandler i) -> H.Attr i
+onfocus :: forall m i. (Event FocusEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onfocusin`
 
 ``` purescript
-onfocusin :: forall i. (Event FocusEvent -> EventHandler i) -> H.Attr i
+onfocusin :: forall m i. (Event FocusEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
 #### `onfocusout`
 
 ``` purescript
-onfocusout :: forall i. (Event FocusEvent -> EventHandler i) -> H.Attr i
+onfocusout :: forall m i. (Event FocusEvent -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 
@@ -345,9 +353,6 @@ type EventHandler = EventHandlerT Identity
 ```
 
 `EventHandler` is a synonym for `EventHandlerT` applied to the `Identity` monad.
-
-That is, `EventHandler` only adds the `preventDefault`, `stopPropagation`,
-`stopImmediatePropagation` and `cancel` actions to the underlying monad.
 
 #### `preventDefault`
 

--- a/docs/Halogen-Events.md
+++ b/docs/Halogen-Events.md
@@ -64,6 +64,14 @@ This function provides an alternative to making two nested calls to `pure`:
 onclick (input \_ -> Input)
 ```
 
+#### `withEventHandlerT`
+
+``` purescript
+withEventHandlerT :: forall i m e. (e -> EventHandlerT m i) -> e -> EventHandler (m i)
+```
+
+Create an event handler which uses `EventHandlerT`.
+
 #### `onabort`
 
 ``` purescript

--- a/docs/Halogen-Events.md
+++ b/docs/Halogen-Events.md
@@ -309,13 +309,13 @@ onfocusout :: forall i. (Event FocusEvent -> EventHandler i) -> H.Attr i
 This module defines the `EventHandler` functor, which can be used
 to perform standard operations on HTML events.
 
-#### `EventHandler`
+#### `EventHandlerT`
 
 ``` purescript
-newtype EventHandler a
+data EventHandlerT m a
 ```
 
-This monad supports the following operations on events:
+This `Applicative` transformer supports the following operations on events:
 
 - `preventDefault`
 - `stopPropagation`
@@ -330,10 +330,21 @@ import Control.Functor (($>))
 H.a (E.onclick \_ -> E.preventDefault $> ClickHandler) (H.text "Click here")
 ```
 
+#### `EventHandler`
+
+``` purescript
+type EventHandler = EventHandlerT Identity
+```
+
+`EventHandler` is a synonym for `EventHandlerT` applied to the `Identity` monad.
+
+That is, `EventHandler` only adds the `preventDefault`, `stopPropagation`,
+`stopImmediatePropagation` and `cancel` actions to the underlying monad.
+
 #### `preventDefault`
 
 ``` purescript
-preventDefault :: EventHandler Unit
+preventDefault :: forall m. (Applicative m) => EventHandlerT m Unit
 ```
 
 Call the `preventDefault` method on the current event
@@ -341,7 +352,7 @@ Call the `preventDefault` method on the current event
 #### `stopPropagation`
 
 ``` purescript
-stopPropagation :: EventHandler Unit
+stopPropagation :: forall m. (Applicative m) => EventHandlerT m Unit
 ```
 
 Call the `stopPropagation` method on the current event
@@ -349,7 +360,7 @@ Call the `stopPropagation` method on the current event
 #### `stopImmediatePropagation`
 
 ``` purescript
-stopImmediatePropagation :: EventHandler Unit
+stopImmediatePropagation :: forall m. (Applicative m) => EventHandlerT m Unit
 ```
 
 Call the `stopImmediatePropagation` method on the current event
@@ -357,43 +368,45 @@ Call the `stopImmediatePropagation` method on the current event
 #### `cancel`
 
 ``` purescript
-cancel :: forall a. EventHandler a
+cancel :: forall m a. EventHandlerT m a
 ```
 
 Cancel the event, so that no input data will be passed to the signal function
 
+#### `liftEventHandler`
+
+``` purescript
+liftEventHandler :: forall m a. m a -> EventHandlerT m a
+```
+
+Lift an action into the `EventHandlerT` transformer
+
+#### `unwrapEventHandler`
+
+``` purescript
+unwrapEventHandler :: forall m a. EventHandlerT m a -> EventHandler (m a)
+```
+
+Interpret `EventHandlerT` in terms of `EventHandler`.
+
 #### `functorEventHandler`
 
 ``` purescript
-instance functorEventHandler :: Functor EventHandler
+instance functorEventHandler :: (Functor m) => Functor (EventHandlerT m)
 ```
 
 
 #### `applyEventHandler`
 
 ``` purescript
-instance applyEventHandler :: Apply EventHandler
+instance applyEventHandler :: (Apply m) => Apply (EventHandlerT m)
 ```
 
 
 #### `applicativeEventHandler`
 
 ``` purescript
-instance applicativeEventHandler :: Applicative EventHandler
-```
-
-
-#### `bindEventHandler`
-
-``` purescript
-instance bindEventHandler :: Bind EventHandler
-```
-
-
-#### `monadEventHandler`
-
-``` purescript
-instance monadEventHandler :: Monad EventHandler
+instance applicativeEventHandler :: (Applicative m) => Applicative (EventHandlerT m)
 ```
 
 

--- a/docs/Halogen-Forms.md
+++ b/docs/Halogen-Forms.md
@@ -8,7 +8,7 @@ Convenience functions for working with form elements.
 #### `onValueChanged`
 
 ``` purescript
-onValueChanged :: forall value i. (IsForeign value) => (value -> EventHandler i) -> H.Attr i
+onValueChanged :: forall value m i. (IsForeign value) => (value -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 Attach an event handler which will produce an input when the value of an input field changes
@@ -18,7 +18,7 @@ An input will not be produced if the value cannot be cast to the appropriate typ
 #### `onChecked`
 
 ``` purescript
-onChecked :: forall i. (Boolean -> EventHandler i) -> H.Attr i
+onChecked :: forall m i. (Boolean -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 Attach an event handler which will fire when a checkbox is checked or unchecked
@@ -26,7 +26,7 @@ Attach an event handler which will fire when a checkbox is checked or unchecked
 #### `onInput`
 
 ``` purescript
-onInput :: forall value i. (IsForeign value) => (value -> EventHandler i) -> H.Attr i
+onInput :: forall value m i. (IsForeign value) => (value -> EventHandlerT m i) -> H.Attr (m i)
 ```
 
 Attach an event handler which will fire on input

--- a/docs/Halogen-Target.md
+++ b/docs/Halogen-Target.md
@@ -47,7 +47,7 @@ There are two types of target:
 #### `target`
 
 ``` purescript
-target :: forall i. Target i -> [A.Attr i]
+target :: forall m i. (Applicative m) => Target i -> [A.Attr (m i)]
 ```
 
 Attach a `Target` to an element using the `href` or `onclick` attribute as appropriate

--- a/examples/ajax/Main.purs
+++ b/examples/ajax/Main.purs
@@ -85,7 +85,7 @@ ui = component (render <$> stateful (State false exampleCode Nothing) update)
           , H.h2_ [ H.text "purescript code" ]
           , H.p_ [ H.textarea [ A.class_ B.formControl 
                               , A.value code 
-                              , A.onInput (A.input SetCode)
+                              , A.onInput $ A.input SetCode
                               , A.style (A.styles $ StrMap.fromList 
                                           [ Tuple "font-family" "monospace"
                                           , Tuple "height" "200px"
@@ -93,7 +93,7 @@ ui = component (render <$> stateful (State false exampleCode Nothing) update)
                               ] [] ]
           , H.p_ [ H.button [ A.classes [B.btn, B.btnPrimary]
                             , A.disabled busy
-                            , A.onclick (\_ -> pure (handler code))
+                            , A.onclick \_ -> E.liftEventHandler (handler code)
                             ] [ H.text "Compile" ] ]
           , H.p_ [ H.text (if busy then "Working..." else "") ]
           ] ++ flip foldMap result \js ->

--- a/purescript-halogen-bootstrap/src/Halogen/Themes/Bootstrap3/Breadcrumbs.purs
+++ b/purescript-halogen-bootstrap/src/Halogen/Themes/Bootstrap3/Breadcrumbs.purs
@@ -23,14 +23,14 @@ import qualified Halogen.Themes.Bootstrap3 as B
 data CrumbTrail a = CrumbTrail [Tuple String (Target a)] String [Tuple String (Target a)]
 
 -- | Create a breadcrumb navigation element from an array of `Crumb`s.
-breadcrumbs :: forall p i. CrumbTrail i -> H.HTML p i
+breadcrumbs :: forall m p i. (Applicative m) => CrumbTrail i -> H.HTML p (m i)
 breadcrumbs (CrumbTrail behind here inFront) = 
   H.ol [ A.class_ B.breadcrumb ] 
   ( map fromCrumb behind ++ 
     [ H.li [ A.class_ B.active ] [ H.text here ] ] ++
     map fromCrumb inFront )
   where
-  fromCrumb :: Tuple String (Target i) -> H.HTML p i
+  fromCrumb :: Tuple String (Target i) -> H.HTML p (m i)
   fromCrumb (Tuple text cr) = 
     let attr = case cr of
                  LinkTarget url -> [A.href (runURL url)]

--- a/purescript-halogen-bootstrap/src/Halogen/Themes/Bootstrap3/Navbar.purs
+++ b/purescript-halogen-bootstrap/src/Halogen/Themes/Bootstrap3/Navbar.purs
@@ -66,27 +66,27 @@ type NavBar a =
   }
 
 -- | Create a navbar from a configuration object.
-navbar :: forall p i. NavBar i -> H.HTML p i
+navbar :: forall m p i. (Applicative m) => NavBar i -> H.HTML p (m i)
 navbar conf = 
   H.nav [ A.classes [B.navbar, B.navbarDefault] ]
         [ H.div [ A.class_ B.containerFluid ] (map renderItem conf.items) ]
         
   where
-  renderItem :: NavBarItem i -> H.HTML p i
+  renderItem :: NavBarItem i -> H.HTML p (m i)
   renderItem (Brand o) = H.a (A.class_ B.navbarBrand : target o.target) [H.text o.text]
   renderItem (Nav o) = H.ul [ A.classes [B.nav, B.navbarNav] ] (map renderNavItem o.items)
   renderItem (Text s) = H.p [ A.class_ B.navbarText ] [H.text s]
   renderItem (Button o) = H.a (A.classes [B.btn, B.btnDefault, B.navbarBtn] : target o.target) [H.text o.text]
   
-  renderNavItem :: NavItem i -> H.HTML p i
+  renderNavItem :: NavItem i -> H.HTML p (m i)
   renderNavItem (NavLink o) = H.li (if o.active then [A.class_ B.active] else []) [ H.a (target o.target) [ H.text o.text ] ]
   renderNavItem (NavDropDown o) = H.li [ A.class_ B.dropdown ] 
                                        [ H.a [ A.href "#", A.class_ B.dropdownToggle ] [H.text o.text] 
                                        , H.ul [ A.class_ B.dropdownMenu ] (intercalate [divider] (map (map renderLink) o.groups))
                                        ]
     where
-    divider :: H.HTML p i
+    divider :: H.HTML p (m i)
     divider = H.li [ A.class_ B.divider ] []
         
-    renderLink :: Link i -> H.HTML p i
+    renderLink :: Link i -> H.HTML p (m i)
     renderLink o = H.li_ [ H.a (target o.target) [ H.text o.text ] ]

--- a/src/Halogen/HTML/Events.purs
+++ b/src/Halogen/HTML/Events.purs
@@ -4,6 +4,7 @@
 module Halogen.HTML.Events 
   ( input
   , withEventHandlerT
+  , handlerT
   
   , onabort
   , onbeforeunload
@@ -58,111 +59,115 @@ import qualified Halogen.HTML.Attributes as H
 -- | ```purescript
 -- | onclick (input \_ -> Input)
 -- | ```
-input :: forall i m a. (Applicative m) => (a -> i) -> a -> EventHandler (m i)
-input f e = pure (pure (f e))
+input :: forall i m a. (Applicative m) => (a -> i) -> a -> EventHandlerT m i
+input f e = pure (f e)
 
 -- | Create an event handler which uses `EventHandlerT`.
 withEventHandlerT :: forall i m e. (e -> EventHandlerT m i) -> e -> EventHandler (m i)
 withEventHandlerT f = unwrapEventHandler <<< f
 
-onabort	:: forall i. (Event () -> EventHandler i) -> H.Attr i
-onabort = H.handler (H.eventName "abort")
+-- | Attach an event handler which uses `EventHandlerT`.
+handlerT :: forall fields m i. H.EventName fields -> (Event fields -> EventHandlerT m i) -> H.Attr (m i)
+handlerT name = H.handler name <<< withEventHandlerT
 
-onbeforeunload :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onbeforeunload = H.handler (H.eventName "beforeunload")
+onabort	:: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onabort = handlerT (H.eventName "abort")
 
-onerror :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onerror = H.handler (H.eventName "error")
+onbeforeunload :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onbeforeunload = handlerT (H.eventName "beforeunload")
 
-onhashchange :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onhashchange = H.handler (H.eventName "hashchange")
+onerror :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onerror = handlerT (H.eventName "error")
 
-onload :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onload = H.handler (H.eventName "load")
+onhashchange :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onhashchange = handlerT (H.eventName "hashchange")
 
-onpageshow :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onpageshow = H.handler (H.eventName "pageshow")
+onload :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onload = handlerT (H.eventName "load")
 
-onpagehide :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onpagehide = H.handler (H.eventName "pagehide")
+onpageshow :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onpageshow = handlerT (H.eventName "pageshow")
 
-onresize :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onresize = H.handler (H.eventName "resize")
+onpagehide :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onpagehide = handlerT (H.eventName "pagehide")
 
-onscroll :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onscroll = H.handler (H.eventName "scroll")
+onresize :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onresize = handlerT (H.eventName "resize")
 
-onunload :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onunload = H.handler (H.eventName "unload")
+onscroll :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onscroll = handlerT (H.eventName "scroll")
 
-onchange :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onchange = H.handler (H.eventName "change")
+onunload :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onunload = handlerT (H.eventName "unload")
 
-oninput :: forall i. (Event () -> EventHandler i) -> H.Attr i
-oninput = H.handler (H.eventName "input")
+onchange :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onchange = handlerT (H.eventName "change")
 
-oninvalid :: forall i. (Event () -> EventHandler i) -> H.Attr i
-oninvalid = H.handler (H.eventName "invalid")
+oninput :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+oninput = handlerT (H.eventName "input")
 
-onreset :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onreset = H.handler (H.eventName "reset")
+oninvalid :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+oninvalid = handlerT (H.eventName "invalid")
 
-onsearch :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onsearch = H.handler (H.eventName "search")
+onreset :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onreset = handlerT (H.eventName "reset")
 
-onselect :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onselect = H.handler (H.eventName "select")
+onsearch :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onsearch = handlerT (H.eventName "search")
 
-onsubmit :: forall i. (Event () -> EventHandler i) -> H.Attr i
-onsubmit = H.handler (H.eventName "submit")
+onselect :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onselect = handlerT (H.eventName "select")
 
-onclick :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
-onclick = H.handler (H.eventName "click")
+onsubmit :: forall m i. (Event () -> EventHandlerT m i) -> H.Attr (m i)
+onsubmit = handlerT (H.eventName "submit")
 
-oncontextmenu :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
-oncontextmenu = H.handler (H.eventName "contextmenu")
+onclick :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
+onclick = handlerT (H.eventName "click")
 
-ondblclick :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
-ondblclick = H.handler (H.eventName "dblclick")
+oncontextmenu :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
+oncontextmenu = handlerT (H.eventName "contextmenu")
 
-onmousedown :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
-onmousedown = H.handler (H.eventName "mousedown")
+ondblclick :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
+ondblclick = handlerT (H.eventName "dblclick")
 
-onmouseenter :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
-onmouseenter = H.handler (H.eventName "mouseenter")
+onmousedown :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
+onmousedown = handlerT (H.eventName "mousedown")
 
-onmouseleave :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
-onmouseleave = H.handler (H.eventName "mouseleave")
+onmouseenter :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
+onmouseenter = handlerT (H.eventName "mouseenter")
 
-onmousemove :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
-onmousemove = H.handler (H.eventName "mousemove")
+onmouseleave :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
+onmouseleave = handlerT (H.eventName "mouseleave")
 
-onmouseover :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
-onmouseover = H.handler (H.eventName "mouseover")
+onmousemove :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
+onmousemove = handlerT (H.eventName "mousemove")
 
-onmouseout :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
-onmouseout = H.handler (H.eventName "mouseout")
+onmouseover :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
+onmouseover = handlerT (H.eventName "mouseover")
 
-onmouseup :: forall i. (Event MouseEvent -> EventHandler i) -> H.Attr i
-onmouseup = H.handler (H.eventName "mouseup")
+onmouseout :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
+onmouseout = handlerT (H.eventName "mouseout")
 
-onkeydown :: forall i. (Event KeyboardEvent -> EventHandler i) -> H.Attr i
-onkeydown = H.handler (H.eventName "keydown")
+onmouseup :: forall m i. (Event MouseEvent -> EventHandlerT m i) -> H.Attr (m i)
+onmouseup = handlerT (H.eventName "mouseup")
 
-onkeypress :: forall i. (Event KeyboardEvent -> EventHandler i) -> H.Attr i
-onkeypress = H.handler (H.eventName "keypress")
+onkeydown :: forall m i. (Event KeyboardEvent -> EventHandlerT m i) -> H.Attr (m i)
+onkeydown = handlerT (H.eventName "keydown")
 
-onkeyup :: forall i. (Event KeyboardEvent -> EventHandler i) -> H.Attr i
-onkeyup = H.handler (H.eventName "keyup")
+onkeypress :: forall m i. (Event KeyboardEvent -> EventHandlerT m i) -> H.Attr (m i)
+onkeypress = handlerT (H.eventName "keypress")
 
-onblur :: forall i. (Event FocusEvent -> EventHandler i) -> H.Attr i
-onblur = H.handler (H.eventName "blur")
+onkeyup :: forall m i. (Event KeyboardEvent -> EventHandlerT m i) -> H.Attr (m i)
+onkeyup = handlerT (H.eventName "keyup")
 
-onfocus :: forall i. (Event FocusEvent -> EventHandler i) -> H.Attr i
-onfocus = H.handler (H.eventName "focus")
+onblur :: forall m i. (Event FocusEvent -> EventHandlerT m i) -> H.Attr (m i)
+onblur = handlerT (H.eventName "blur")
 
-onfocusin :: forall i. (Event FocusEvent -> EventHandler i) -> H.Attr i
-onfocusin = H.handler (H.eventName "focusin")
+onfocus :: forall m i. (Event FocusEvent -> EventHandlerT m i) -> H.Attr (m i)
+onfocus = handlerT (H.eventName "focus")
 
-onfocusout :: forall i. (Event FocusEvent -> EventHandler i) -> H.Attr i
-onfocusout = H.handler (H.eventName "focusout")
+onfocusin :: forall m i. (Event FocusEvent -> EventHandlerT m i) -> H.Attr (m i)
+onfocusin = handlerT (H.eventName "focusin")
+
+onfocusout :: forall m i. (Event FocusEvent -> EventHandlerT m i) -> H.Attr (m i)
+onfocusout = handlerT (H.eventName "focusout")

--- a/src/Halogen/HTML/Events.purs
+++ b/src/Halogen/HTML/Events.purs
@@ -11,33 +11,33 @@ module Halogen.HTML.Events
   , onload
   , onpageshow
   , onpagehide
-  , onresize
-  , onscroll
-  , onunload
-  , onchange
-  , oninput
+  , onresize 
+  , onscroll 
+  , onunload 
+  , onchange 
+  , oninput  
   , oninvalid
-  , onreset
-  , onsearch
-  , onselect
-  , onsubmit
-  , onclick
-  , oncontextmenu
-  , ondblclick
-  , onmousedown
+  , onreset  
+  , onsearch 
+  , onselect 
+  , onsubmit 
+  , onclick  
+  , oncontextmenu 
+  , ondblclick  
+  , onmousedown 
   , onmouseenter
   , onmouseleave
-  , onmousemove
-  , onmouseover
-  , onmouseout
-  , onmouseup
-  , onkeydown
-  , onkeypress
-  , onkeyup
-  , onblur 
-  , onfocus
-  , onfocusin
-  , onfocusout
+  , onmousemove 
+  , onmouseover 
+  , onmouseout  
+  , onmouseup   
+  , onkeydown   
+  , onkeypress  
+  , onkeyup     
+  , onblur      
+  , onfocus     
+  , onfocusin   
+  , onfocusout  
   ) where
 
 import Data.Maybe
@@ -59,6 +59,10 @@ import qualified Halogen.HTML.Attributes as H
 -- | ```
 input :: forall i m a. (Applicative m) => (a -> i) -> a -> EventHandler (m i)
 input f e = pure (pure (f e))
+
+-- | Create an event handler which uses `EventHandlerT`.
+withEventHandlerT :: forall i m e. (e -> EventHandlerT m i) -> e -> EventHandler (m i)
+withEventHandlerT f = unwrapEventHandler <<< f
 
 onabort	:: forall i. (Event () -> EventHandler i) -> H.Attr i
 onabort = H.handler (H.eventName "abort")

--- a/src/Halogen/HTML/Events.purs
+++ b/src/Halogen/HTML/Events.purs
@@ -3,6 +3,7 @@
 
 module Halogen.HTML.Events 
   ( input
+  , withEventHandlerT
   
   , onabort
   , onbeforeunload

--- a/src/Halogen/HTML/Events/Forms.purs
+++ b/src/Halogen/HTML/Events/Forms.purs
@@ -16,28 +16,29 @@ import Data.Traversable (traverse)
 
 import Halogen.HTML.Events.Handler
 
+import qualified Halogen.HTML.Events as E
 import qualified Halogen.HTML.Attributes as H
   
 -- | Attach event handler to event ```key``` with getting ```prop``` field
 -- | as an argument of handler
-addForeignPropHandler :: forall i value. (IsForeign value) => String -> String -> (value -> EventHandler i) -> H.Attr i
-addForeignPropHandler key prop f = H.handler (H.eventName key) handler
+addForeignPropHandler :: forall value m i. (IsForeign value) => String -> String -> (value -> EventHandlerT m i) -> H.Attr (m i)
+addForeignPropHandler key prop f = E.handlerT (H.eventName key) (\e -> handler (toForeign e.target))
   where
-  handler :: forall e. e -> EventHandler i
-  handler e = case readProp prop (toForeign e) of
+  handler :: Foreign -> EventHandlerT m i
+  handler e = case readProp prop e of
                 Left _ -> cancel
                 Right i -> f i
 
 -- | Attach an event handler which will produce an input when the value of an input field changes
 -- |
 -- | An input will not be produced if the value cannot be cast to the appropriate type.
-onValueChanged :: forall value i. (IsForeign value) => (value -> EventHandler i) -> H.Attr i
+onValueChanged :: forall value m i. (IsForeign value) => (value -> EventHandlerT m i) -> H.Attr (m i)
 onValueChanged = addForeignPropHandler "change" "value"
 
 -- | Attach an event handler which will fire when a checkbox is checked or unchecked
-onChecked :: forall i. (Boolean -> EventHandler i) -> H.Attr i
+onChecked :: forall m i. (Boolean -> EventHandlerT m i) -> H.Attr (m i)
 onChecked = addForeignPropHandler "change" "checked"
 
 -- | Attach an event handler which will fire on input
-onInput :: forall value i. (IsForeign value) => (value -> EventHandler i) -> H.Attr i
+onInput :: forall value m i. (IsForeign value) => (value -> EventHandlerT m i) -> H.Attr (m i)
 onInput = addForeignPropHandler "input" "value"

--- a/src/Halogen/HTML/Events/Handler.purs
+++ b/src/Halogen/HTML/Events/Handler.purs
@@ -3,13 +3,17 @@
 
 module Halogen.HTML.Events.Handler 
   ( EventHandler()
+  , EventHandlerT()
   
   , preventDefault 
   , stopPropagation
   , stopImmediatePropagation
   , cancel
   
+  , liftEventHandler
+  
   , runEventHandler
+  , unwrapEventHandler
   ) where
 
 import DOM
@@ -18,16 +22,12 @@ import Data.Maybe
 import Data.Tuple
 import Data.Array ()
 import Data.Foldable (for_)
+import Data.Traversable (sequence)
+import Data.Identity
 
-import Control.Apply ((*>))
+import Control.Apply (lift2, (*>))
 import Control.Plus (empty)
 import Control.Monad.Eff
-
-import Control.Monad.Maybe.Trans
-
-import Control.Monad.Writer
-import Control.Monad.Writer.Trans
-import Control.Monad.Writer.Class
 
 import Halogen.HTML.Events.Types
 
@@ -36,7 +36,7 @@ data EventUpdate
   | StopPropagation
   | StopImmediatePropagation
 
--- | This monad supports the following operations on events:
+-- | This `Applicative` transformer supports the following operations on events:
 -- |
 -- | - `preventDefault`
 -- | - `stopPropagation`
@@ -50,40 +50,49 @@ data EventUpdate
 -- |
 -- | H.a (E.onclick \_ -> E.preventDefault $> ClickHandler) (H.text "Click here")
 -- | ```
-newtype EventHandler a = EventHandler (MaybeT (Writer [EventUpdate]) a)
+data EventHandlerT m a = EventHandlerT [EventUpdate] (Maybe (m a))
+
+-- | `EventHandler` is a synonym for `EventHandlerT` applied to the `Identity` monad.
+-- | 
+-- | That is, `EventHandler` only adds the `preventDefault`, `stopPropagation`,
+-- | `stopImmediatePropagation` and `cancel` actions to the underlying monad.
+type EventHandler = EventHandlerT Identity
      
-unEventHandler :: forall a. EventHandler a -> MaybeT (Writer [EventUpdate]) a
-unEventHandler (EventHandler mw) = mw
-     
+log :: forall m. (Applicative m) => EventUpdate -> EventHandlerT m Unit
+log e = EventHandlerT [e] (Just (pure unit))
+
 -- | Call the `preventDefault` method on the current event
-preventDefault :: EventHandler Unit
-preventDefault = EventHandler (tell [PreventDefault])
+preventDefault :: forall m. (Applicative m) => EventHandlerT m Unit
+preventDefault = log PreventDefault
      
 -- | Call the `stopPropagation` method on the current event
-stopPropagation :: EventHandler Unit
-stopPropagation = EventHandler (tell [StopPropagation])
+stopPropagation :: forall m. (Applicative m) => EventHandlerT m Unit
+stopPropagation = log StopPropagation
      
 -- | Call the `stopImmediatePropagation` method on the current event
-stopImmediatePropagation :: EventHandler Unit
-stopImmediatePropagation = EventHandler (tell [StopImmediatePropagation])
+stopImmediatePropagation :: forall m. (Applicative m) => EventHandlerT m Unit
+stopImmediatePropagation = log StopImmediatePropagation
      
 -- | Cancel the event, so that no input data will be passed to the signal function
-cancel :: forall a. EventHandler a
-cancel = EventHandler empty
+cancel :: forall m a. EventHandlerT m a
+cancel = EventHandlerT [] Nothing
+
+-- | Lift an action into the `EventHandlerT` transformer
+liftEventHandler :: forall m a. m a -> EventHandlerT m a
+liftEventHandler = EventHandlerT [] <<< Just
+     
+-- | Interpret `EventHandlerT` in terms of `EventHandler`.
+unwrapEventHandler :: forall m a. EventHandlerT m a -> EventHandler (m a)
+unwrapEventHandler (EventHandlerT es ma) = EventHandlerT es (Identity <$> ma)
       
-instance functorEventHandler :: Functor EventHandler where
-  (<$>) f (EventHandler mw) = EventHandler (f <$> mw)
-
-instance applyEventHandler :: Apply EventHandler where
-  (<*>) (EventHandler mw1) (EventHandler mw2) = EventHandler (mw1 <*> mw2)
-
-instance applicativeEventHandler :: Applicative EventHandler where
-  pure = EventHandler <<< pure
-
-instance bindEventHandler :: Bind EventHandler where
-  (>>=) (EventHandler mw) f = EventHandler (mw >>= unEventHandler <<< f)
+instance functorEventHandler :: (Functor m) => Functor (EventHandlerT m) where
+  (<$>) f (EventHandlerT es m) = EventHandlerT es ((f <$>) <$> m)
   
-instance monadEventHandler :: Monad EventHandler
+instance applyEventHandler :: (Apply m) => Apply (EventHandlerT m) where
+  (<*>) (EventHandlerT es1 m1) (EventHandlerT es2 m2) = EventHandlerT (es1 <> es2) (lift2 (<*>) m1 m2)
+
+instance applicativeEventHandler :: (Applicative m) => Applicative (EventHandlerT m) where
+  pure a = EventHandlerT [] (Just (pure a))
   
 foreign import preventDefaultImpl
   "function preventDefaultImpl(e) {\
@@ -108,9 +117,9 @@ foreign import stopImmediatePropagationImpl
       
 -- | This function can be used to update an event and return the wrapped value
 runEventHandler :: forall a fields eff. Event fields -> EventHandler a -> Eff (dom :: DOM | eff) (Maybe a)
-runEventHandler e (EventHandler mw) = 
-  case runWriter (runMaybeT mw) of
-    Tuple ma eus -> for_ eus applyUpdate *> return ma
+runEventHandler e (EventHandlerT es ma) = do
+  for_ es applyUpdate
+  return (runIdentity (sequence ma))
   where
   applyUpdate :: EventUpdate -> Eff (dom :: DOM | eff) Unit
   applyUpdate PreventDefault            = preventDefaultImpl e

--- a/src/Halogen/HTML/Events/Handler.purs
+++ b/src/Halogen/HTML/Events/Handler.purs
@@ -53,9 +53,6 @@ data EventUpdate
 data EventHandlerT m a = EventHandlerT [EventUpdate] (Maybe (m a))
 
 -- | `EventHandler` is a synonym for `EventHandlerT` applied to the `Identity` monad.
--- | 
--- | That is, `EventHandler` only adds the `preventDefault`, `stopPropagation`,
--- | `stopImmediatePropagation` and `cancel` actions to the underlying monad.
 type EventHandler = EventHandlerT Identity
      
 log :: forall m. (Applicative m) => EventUpdate -> EventHandlerT m Unit

--- a/src/Halogen/HTML/Target.purs
+++ b/src/Halogen/HTML/Target.purs
@@ -38,6 +38,6 @@ runURL (URL s) = s
 data Target a = LinkTarget URL | DataTarget a
 
 -- | Attach a `Target` to an element using the `href` or `onclick` attribute as appropriate
-target :: forall i. Target i -> [A.Attr i]
+target :: forall m i. (Applicative m) => Target i -> [A.Attr (m i)]
 target (LinkTarget url) = [ A.href (runURL url) ]
 target (DataTarget i) = [ A.href "#", E.onclick (\_ -> E.preventDefault $> i) ]


### PR DESCRIPTION
@jdegoes @puffnfresh @garyb @cryogenian Could you please review this before I merge?

The goal was to get rid of `pure <<< pure`, which this does, but `EventHandlerT` is _not_ a `Monad` transformer, but only an `Applicative` transformer, for a technical reason.

Naively, it seems like `MaybeT` with `WriterT` is the right thing to interpret the effects, since we want the ability to both bail out, and accumulate a list of things to do with the event object. However, we need to run things like `preventDefault` _before_ any effects (we don't want to wait for `Aff` to return before we `preventDefault`, which doesn't make sense). 

So the thing we want is 

```purescript
data EventHandlerT m a = EventHandlerT [EventUpdate] (Maybe (m a))
```

which isn't a `Monad` in any useful way, but it is an `Applicative`, which I think is enough to be useful.

I've provided helper functions `liftEventHandler` and `withEventHandler` to be able to use `EventHandlerT` where it is useful.

How does this look?

Aside from docs, which I plan to write now, this wraps up 0.4 I think...