### PR TITLE
Fix #53, support component initialization

### DIFF
--- a/docs/Halogen-Events.md
+++ b/docs/Halogen-Events.md
@@ -506,6 +506,13 @@ instance monadEvent :: Monad (Event eff)
 ```
 
 
+#### `monadEffEvent`
+
+``` purescript
+instance monadEffEvent :: MonadEff eff (Event eff)
+```
+
+
 #### `monadAffEvent`
 
 ``` purescript

--- a/docs/Halogen-HTML.md
+++ b/docs/Halogen-HTML.md
@@ -1825,7 +1825,8 @@ the `Attr` type.
 data Attr i
   = Attr (Exists AttrF)
   | Handler (ExistsR (HandlerF i))
-  | Initializer (Boolean -> i)
+  | Initializer i
+  | Finalizer i
 ```
 
 A single attribute is either
@@ -1859,13 +1860,18 @@ Create an event handler
 #### `initializer`
 
 ``` purescript
-initializer :: forall i. (Boolean -> i) -> Attr i
+initializer :: forall i. i -> Attr i
 ```
 
-Create an initializer function.
+Attach an initializer.
 
-The initializer will receive a Boolean value which indicates whether the component is being
-initialized for the first time, or just rerendered.
+#### `finalizer`
+
+``` purescript
+finalizer :: forall i. i -> Attr i
+```
+
+Attach a finalizer.
 
 #### `ClassName`
 

--- a/docs/Halogen-HTML.md
+++ b/docs/Halogen-HTML.md
@@ -1825,6 +1825,7 @@ the `Attr` type.
 data Attr i
   = Attr (Exists AttrF)
   | Handler (ExistsR (HandlerF i))
+  | Initializer (Boolean -> i)
 ```
 
 A single attribute is either
@@ -1854,6 +1855,17 @@ handler :: forall fields i. EventName fields -> (Event fields -> EventHandler i)
 ```
 
 Create an event handler
+
+#### `initializer`
+
+``` purescript
+initializer :: forall i. (Boolean -> i) -> Attr i
+```
+
+Create an initializer function.
+
+The initializer will receive a Boolean value which indicates whether the component is being
+initialized for the first time, or just rerendered.
 
 #### `ClassName`
 

--- a/examples/ajax/Main.purs
+++ b/examples/ajax/Main.purs
@@ -11,10 +11,14 @@ import qualified Data.String as S
 import qualified Data.StrMap as StrMap
 
 import Control.Functor (($>))
+import Control.Plus (empty)
+
 import Control.Monad.Eff
+import Control.Monad.Eff.Class
 import Control.Monad.Aff
 
 import DOM
+import Debug.Trace
 
 import Halogen
 import Halogen.Signal
@@ -80,7 +84,7 @@ ui = component (render <$> stateful (State false exampleCode Nothing) update)
   where
   render :: State -> H.HTML p (E.Event (HalogenEffects (http :: HTTP | eff)) Input)
   render (State busy code result) = 
-    H.div [ A.class_ B.container ] $
+    H.div [ A.class_ B.container, A.initializer initialized ] $
           [ H.h1 [ A.id_ "header" ] [ H.text "ajax example" ]
           , H.h2_ [ H.text "purescript code" ]
           , H.p_ [ H.textarea [ A.class_ B.formControl 
@@ -105,6 +109,12 @@ ui = component (render <$> stateful (State false exampleCode Nothing) update)
   update (State _ code rslt) SetBusy = State true code rslt
   update (State busy _ _) (SetCode code) = State busy code Nothing
   update (State busy code _) (SetResult rslt) = State false code (Just rslt)
+
+-- | Called when the component is initialized
+initialized :: forall eff. Boolean -> E.Event (HalogenEffects (http :: HTTP | eff)) Input
+initialized b = do
+  liftEff $ trace $ "UI initialized: " <> show b
+  empty
 
 -- | Handle a request to an external service
 handler :: forall eff. String -> E.Event (HalogenEffects (http :: HTTP | eff)) Input

--- a/examples/ajax/Main.purs
+++ b/examples/ajax/Main.purs
@@ -84,7 +84,7 @@ ui = component (render <$> stateful (State false exampleCode Nothing) update)
   where
   render :: State -> H.HTML p (E.Event (HalogenEffects (http :: HTTP | eff)) Input)
   render (State busy code result) = 
-    H.div [ A.class_ B.container, A.initializer initialized ] $
+    H.div [ A.class_ B.container ] $
           [ H.h1 [ A.id_ "header" ] [ H.text "ajax example" ]
           , H.h2_ [ H.text "purescript code" ]
           , H.p_ [ H.textarea [ A.class_ B.formControl 
@@ -101,9 +101,10 @@ ui = component (render <$> stateful (State false exampleCode Nothing) update)
                             ] [ H.text "Compile" ] ]
           , H.p_ [ H.text (if busy then "Working..." else "") ]
           ] ++ flip foldMap result \js ->
-          [ H.h2_ [ H.text "compiled javascript" ]
-          , H.pre_ [ H.code_ [ H.text js ] ]
-          ]
+          [ H.div [ A.initializer initialized, A.finalizer finalized ] 
+                  [ H.h2_ [ H.text "compiled javascript" ]
+                  , H.pre_ [ H.code_ [ H.text js ] ]
+                  ] ]
 
   update :: State -> Input -> State
   update (State _ code rslt) SetBusy = State true code rslt
@@ -111,9 +112,15 @@ ui = component (render <$> stateful (State false exampleCode Nothing) update)
   update (State busy code _) (SetResult rslt) = State false code (Just rslt)
 
 -- | Called when the component is initialized
-initialized :: forall eff. Boolean -> E.Event (HalogenEffects (http :: HTTP | eff)) Input
-initialized b = do
-  liftEff $ trace $ "UI initialized: " <> show b
+initialized :: forall eff. E.Event (HalogenEffects (http :: HTTP | eff)) Input
+initialized = do
+  liftEff $ trace "UI initialized"
+  empty
+  
+-- | Called when the component is finalized
+finalized :: forall eff. E.Event (HalogenEffects (http :: HTTP | eff)) Input
+finalized = do
+  liftEff $ trace "UI finalized"
   empty
 
 -- | Handle a request to an external service

--- a/src/Halogen/HTML/Events/Monad.purs
+++ b/src/Halogen/HTML/Events/Monad.purs
@@ -25,6 +25,7 @@ import Control.Monad.Trans
 import Control.Monad.ListT
 
 import Control.Monad.Eff
+import Control.Monad.Eff.Class
 import Control.Monad.Eff.Exception (Error())
 
 import Control.Monad.Aff
@@ -92,6 +93,9 @@ instance bindEvent :: Bind (Event eff) where
   (>>=) (Event l) f = Event (l >>= f >>> unEvent)
 
 instance monadEvent :: Monad (Event eff)
+
+instance monadEffEvent :: MonadEff eff (Event eff) where
+  liftEff = Event <<< lift <<< liftEff
 
 instance monadAffEvent :: MonadAff eff (Event eff) where
   liftAff = Event <<< lift

--- a/src/Halogen/HTML/Renderer/String.purs
+++ b/src/Halogen/HTML/Renderer/String.purs
@@ -21,7 +21,7 @@ import Halogen.HTML.Events.Types
 
 renderAttr :: forall i. A.Attr i -> Maybe String
 renderAttr (A.Attr e) = runExists (\(A.AttrF f key value) -> Just $ A.runAttributeName key <> "=\"" <> f key value <> "\"") e
-renderAttr (A.Handler _) = Nothing
+renderAttr _ = Nothing
 
 -- | Render a HTML document as a `String`, usually for testing purposes.
 renderHTMLToString :: forall i. H.HTML Void i -> String

--- a/src/Halogen/HTML/Renderer/VirtualDOM.purs
+++ b/src/Halogen/HTML/Renderer/VirtualDOM.purs
@@ -24,7 +24,8 @@ renderAttr dr (A.Handler e) = A.runExistsR (\(A.HandlerF name k) ->
   runFn2 handlerProp (A.runEventName name) \ev -> do
     a <- unsafeInterleaveEff $ runEventHandler ev (k ev)
     dr a) e
-renderAttr dr (A.Initializer f) = initProp (dr <<< f)
+renderAttr dr (A.Initializer i) = initProp (dr i)
+renderAttr dr (A.Finalizer i) = finalizerProp (dr i)
 
 -- | Render a `HTML` document to a virtual DOM node
 -- |

--- a/src/Halogen/HTML/Renderer/VirtualDOM.purs
+++ b/src/Halogen/HTML/Renderer/VirtualDOM.purs
@@ -24,6 +24,7 @@ renderAttr dr (A.Handler e) = A.runExistsR (\(A.HandlerF name k) ->
   runFn2 handlerProp (A.runEventName name) \ev -> do
     a <- unsafeInterleaveEff $ runEventHandler ev (k ev)
     dr a) e
+renderAttr dr (A.Initializer f) = initProp (dr <<< f)
 
 -- | Render a `HTML` document to a virtual DOM node
 -- |

--- a/src/Halogen/Internal/VirtualDOM.purs
+++ b/src/Halogen/Internal/VirtualDOM.purs
@@ -9,6 +9,7 @@ module Halogen.Internal.VirtualDOM
   , emptyProps
   , prop
   , handlerProp
+  , initProp
   , createElement
   , diff
   , patch
@@ -57,9 +58,9 @@ foreign import prop
   \  return props;\
   \}" :: forall value. Fn2 String value Props
 
--- | Update a set of mutable properties by attaching a hook for an event
+-- | Create a property from an event handler
 foreign import handlerProp
-  "function handlerProp(key, f, props) {\
+  "function handlerProp(key, f) {\
   \  var props = {};\
   \  var Hook = function () {};\
   \  Hook.prototype.callback = function(e) {\
@@ -74,6 +75,18 @@ foreign import handlerProp
   \  props['halogen-hook-' + key] = new Hook(f);\
   \  return props;\
   \}" :: forall eff event. Fn2 String (event -> Eff eff Unit) Props
+
+-- | Create a property from aninitializer
+foreign import initProp
+  "function initProp(f) {\
+  \  var props = {};\
+  \  var Hook = function () {};\
+  \  Hook.prototype.hook = function(node, prop, prev) {\
+  \    f(typeof prev === 'undefined')();\
+  \  };\
+  \  props['halogen-init'] = new Hook(f);\
+  \  return props;\
+  \}" :: forall eff. (Boolean -> Eff eff Unit) -> Props
 
 foreign import concatProps
   "function concatProps(p1, p2) {\


### PR DESCRIPTION
@garyb @natefaubion @jdegoes Could you please review?

This supports initialization by adding an init hook, and a new type of `Attr`.

There is also an example in `examples/ajax`.