### PR TITLE
Patch for #87

### DIFF
--- a/src/Halogen.purs
+++ b/src/Halogen.purs
@@ -107,10 +107,13 @@ runUI' ref sf = do
   
   driver :: Driver (Either i req) eff
   driver e = do
-    Just { signal: signal, node: node } <- readRef ref
-    let next = runSF signal e
-    node' <- patch (head next) node
-    writeRef ref $ Just { signal: tail next, node: node' }
+    ms <- readRef ref
+    case ms of
+      Just { signal: signal, node: node } -> do
+        let next = runSF signal e
+        node' <- patch (head next) node
+        writeRef ref $ Just { signal: tail next, node: node' }
+      Nothing -> trace "Error: An attempt to re-render was made during the initial render."
     
   externalDriver :: Driver req eff
   externalDriver req = driver (Right req)


### PR DESCRIPTION
@jdegoes This is a band-aid for now. Could you please review?

A correct-by-construction approach is in the works.

_Edit_ : I'm not sure my approach will work. We basically want to ensure that the action associated with the initializer doesn't return immediately, but is asynchronous, so that we don't try to rerender during the first render. I thought of using an indexed monad with the new custom do notation feature, but that won't work, since even if we label `async` and `sync`, there's no way to guarantee an `Aff` action wasn't constructed using, say, `pure`.