### PR TITLE
Provide HTML element to initializer and finalizer

### DIFF
--- a/docs/Halogen-HTML.md
+++ b/docs/Halogen-HTML.md
@@ -1833,8 +1833,8 @@ the `Attr` type.
 data Attr i
   = Attr (Exists AttrF)
   | Handler (ExistsR (HandlerF i))
-  | Initializer i
-  | Finalizer i
+  | Initializer (HTMLElement -> i)
+  | Finalizer (HTMLElement -> i)
 ```
 
 A single attribute is either
@@ -1868,7 +1868,7 @@ Create an event handler
 #### `initializer`
 
 ``` purescript
-initializer :: forall i. i -> Attr i
+initializer :: forall i. (HTMLElement -> i) -> Attr i
 ```
 
 Attach an initializer.
@@ -1876,7 +1876,7 @@ Attach an initializer.
 #### `finalizer`
 
 ``` purescript
-finalizer :: forall i. i -> Attr i
+finalizer :: forall i. (HTMLElement -> i) -> Attr i
 ```
 
 Attach a finalizer.

--- a/src/Halogen/HTML/Renderer/VirtualDOM.purs
+++ b/src/Halogen/HTML/Renderer/VirtualDOM.purs
@@ -24,8 +24,8 @@ renderAttr dr (A.Handler e) = A.runExistsR (\(A.HandlerF name k) ->
   runFn2 handlerProp (A.runEventName name) \ev -> do
     a <- unsafeInterleaveEff $ runEventHandler ev (k ev)
     dr a) e
-renderAttr dr (A.Initializer i) = initProp (dr i)
-renderAttr dr (A.Finalizer i) = finalizerProp (dr i)
+renderAttr dr (A.Initializer i) = initProp (dr <<< i)
+renderAttr dr (A.Finalizer i) = finalizerProp (dr <<< i)
 
 -- | Render a `HTML` document to a virtual DOM node
 -- |

--- a/src/Halogen/Internal/VirtualDOM.purs
+++ b/src/Halogen/Internal/VirtualDOM.purs
@@ -86,12 +86,12 @@ foreign import initProp
   \  var Hook = function () {};\
   \  Hook.prototype.hook = function(node, prop, prev) {\
   \    if (typeof prev === 'undefined') {\
-  \      f();\
+  \      f(node);\
   \    };\
   \  };\
   \  props['halogen-init'] = new Hook(f);\
   \  return props;\
-  \}" :: forall eff. Eff eff Unit -> Props
+  \}" :: forall eff. (HTMLElement -> Eff eff Unit) -> Props
   
 -- | Create a property from an finalizer
 foreign import finalizerProp
@@ -99,12 +99,12 @@ foreign import finalizerProp
   \  var props = {};\
   \  var Hook = function () {};\
   \  Hook.prototype.hook = function() { };\
-  \  Hook.prototype.unhook = function() {\
-  \    f();\
+  \  Hook.prototype.unhook = function(node) {\
+  \    f(node);\
   \  };\
   \  props['halogen-finalizer'] = new Hook(f);\
   \  return props;\
-  \}" :: forall eff. Eff eff Unit -> Props
+  \}" :: forall eff. (HTMLElement -> Eff eff Unit) -> Props
 
 foreign import concatProps
   "function concatProps(p1, p2) {\


### PR DESCRIPTION
@jdegoes A not-very-safe fix for #85. We probably want to limit the `HTMLElement` to read-only access in the event handler. This will let us get the job done for now, but I think I would like to implement this using a fixed set of allowed primitives once there is more time. If we merge this maybe we can create a new issue for that. What do you think?