### PR TITLE
Pulpify all examples

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,8 +31,5 @@
     "purescript-exists": "~0.1.1",
     "purescript-lists": "~0.6.0",
     "purescript-integers": "~0.1.0"
-  },
-  "devDependencies": {
-    "purescript-ace": "~0.3.0"
   }
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+## Halogen Examples
+
+Each project can be built using `pulp`:
+
+```text
+$ pulp dep update
+$ pulp build
+$ pulp browserify > dist/index.js
+```

--- a/examples/ace/.gitignore
+++ b/examples/ace/.gitignore
@@ -1,0 +1,3 @@
+dist
+output
+bower_components

--- a/examples/ace/bower.json
+++ b/examples/ace/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "ace",
+  "version": "1.0.0",
+  "moduleType": [
+    "node"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "output"
+  ],
+  "dependencies": {
+    "purescript-ace": "~0.3.0",
+    "purescript-halogen": "master",
+    "purescript-halogen-bootstrap": "master"
+  }
+}

--- a/examples/ace/index.html
+++ b/examples/ace/index.html
@@ -11,6 +11,6 @@
   </head>
   <body>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js" type="text/javascript" charset="utf-8"></script>
-    <script src="psc.js"></script>
+    <script src="dist/index.js"></script>
   </body>
 </html>

--- a/examples/ace/src/Main.purs
+++ b/examples/ace/src/Main.purs
@@ -1,4 +1,4 @@
-module Example.Ace where
+module Main where
 
 import Data.Void
 import Data.Maybe
@@ -43,11 +43,6 @@ foreign import createEditorNode
   "function createEditorNode() {\
   \  return document.createElement('div');\
   \}" :: forall eff. Eff (dom :: DOM | eff) HTMLElement
-
-foreign import coerceNode
-  "function coerceNode(el) {\
-  \  return el;\
-  \}" :: HTMLElement -> Node
 
 -- | The type of inputs to the Ace widget.
 data AceInput = ClearText
@@ -104,7 +99,7 @@ aceEditor = widget { name: "AceEditor", id: "editor1", init: init, update: updat
   init :: forall eff. (AceEvent -> Eff (ace :: EAce, dom :: DOM | eff) Unit) -> Eff (ace :: EAce, dom :: DOM | eff) { state :: Editor, node :: HTMLElement }
   init driver = do
     node <- createEditorNode
-    editor <- Ace.editNode (coerceNode node) ace
+    editor <- Ace.editNode node ace
     Editor.setTheme "ace/theme/monokai" editor
     Editor.onCopy editor (driver <<< TextCopied)
     return { state: editor, node: node }

--- a/examples/ajax/.gitignore
+++ b/examples/ajax/.gitignore
@@ -1,0 +1,3 @@
+dist
+output
+bower_components

--- a/examples/ajax/bower.json
+++ b/examples/ajax/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "ajax",
+  "version": "1.0.0",
+  "moduleType": [
+    "node"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "output"
+  ],
+  "dependencies": {
+    "purescript-halogen": "master",
+    "purescript-halogen-bootstrap": "master"
+  }
+}

--- a/examples/ajax/bower.json
+++ b/examples/ajax/bower.json
@@ -12,6 +12,10 @@
   ],
   "dependencies": {
     "purescript-halogen": "master",
-    "purescript-halogen-bootstrap": "master"
+    "purescript-halogen-bootstrap": "master",
+    "purescript-affjax": "~0.2.1"
+  },
+  "resolutions": {
+    "purescript-integers": "~0.1.0"
   }
 }

--- a/examples/ajax/index.html
+++ b/examples/ajax/index.html
@@ -5,6 +5,6 @@
     <link href="../bootstrap.min.css" rel="stylesheet">
   </head>
   <body>
-    <script src="psc.js"></script>
+    <script src="dist/index.js"></script>
   </body>
 </html>

--- a/examples/ajax/src/Main.purs
+++ b/examples/ajax/src/Main.purs
@@ -1,4 +1,4 @@
-module Example.Ajax where
+module Main where
 
 import Data.Void
 import Data.Tuple

--- a/examples/counter/.gitignore
+++ b/examples/counter/.gitignore
@@ -1,0 +1,3 @@
+dist
+output
+bower_components

--- a/examples/counter/bower.json
+++ b/examples/counter/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "counter",
+  "version": "1.0.0",
+  "moduleType": [
+    "node"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "output"
+  ],
+  "dependencies": {
+    "purescript-halogen": "master",
+    "purescript-halogen-bootstrap": "master"
+  }
+}

--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -5,6 +5,6 @@
     <link href="../bootstrap.min.css" rel="stylesheet">
   </head>
   <body>
-    <script src="psc.js"></script>
+    <script src="dist/index.js"></script>
   </body>
 </html>

--- a/examples/counter/src/Main.purs
+++ b/examples/counter/src/Main.purs
@@ -1,4 +1,4 @@
-module Example.Counter where
+module Main where
 
 import Data.Void
 import Data.Tuple

--- a/examples/todo/.gitignore
+++ b/examples/todo/.gitignore
@@ -1,0 +1,3 @@
+dist
+output
+bower_components

--- a/examples/todo/bower.json
+++ b/examples/todo/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "purescript-halogen-todo-example",
+  "version": "0.4.1",
+  "moduleType": [
+    "node"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "output"
+  ],
+  "dependencies": {
+    "purescript-halogen": "master",
+    "purescript-halogen-bootstrap": "master"
+  }
+}

--- a/examples/todo/index.html
+++ b/examples/todo/index.html
@@ -5,6 +5,6 @@
     <link href="../bootstrap.min.css" rel="stylesheet">
   </head>
   <body>
-    <script src="psc.js"></script>
+    <script src="dist/index.js"></script>
   </body>
 </html>

--- a/examples/todo/src/Main.purs
+++ b/examples/todo/src/Main.purs
@@ -1,4 +1,4 @@
-module Example.Todo where
+module Main where
 
 import Data.Void
 import Data.Tuple

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,41 +65,7 @@ var paths = {
             dest: 'docs/Halogen-Mixin-Router.md',
             src: 'src/Halogen/Mixin/Router.purs'
         } 
-    ],
-    examples: {
-        todo: {
-            src: ['examples/todo/Main.purs'],
-            dest: 'examples/todo',
-            options: {
-                main: 'Example.Todo',
-                modules: ['Example.Todo']
-            }
-        }, 
-        counter: {
-            src: ['examples/counter/Main.purs'],
-            dest: 'examples/counter',
-            options: {
-                main: 'Example.Counter',
-                modules: ['Example.Counter']
-            }
-        }, 
-        ajax: {
-            src: ['examples/ajax/Main.purs'],
-            dest: 'examples/ajax',
-            options: {
-                main: 'Example.Ajax',
-                modules: ['Example.Ajax']
-            }
-        }, 
-        ace: {
-            src: ['examples/ace/Main.purs'],
-            dest: 'examples/ace',
-            options: {
-                main: 'Example.Ace',
-                modules: ['Example.Ace']
-            }
-        }
-    }
+    ]
 };
 
 function compile (compiler, src, opts) {
@@ -124,34 +90,6 @@ function docs (target) {
         .pipe(gulp.dest(target.dest));
 }
 
-gulp.task('example-todo', function() {
-    return compile(purescript.psc, paths.src.concat(paths.examples.todo.src), paths.examples.todo.options)
-        .pipe(browserify({}))
-        .pipe(gulp.dest(paths.examples.todo.dest));
-});
-
-gulp.task('example-counter', function() {
-    return compile(purescript.psc, paths.src.concat(paths.examples.counter.src), paths.examples.counter.options)
-        .pipe(browserify({}))
-        .pipe(gulp.dest(paths.examples.counter.dest));
-});
-
-gulp.task('example-ajax', function() {
-    return compile(purescript.psc, paths.src.concat(paths.examples.ajax.src), paths.examples.ajax.options)
-        .pipe(browserify({}))
-        .pipe(gulp.dest(paths.examples.ajax.dest));
-});
-
-gulp.task('example-ace', function() {
-    return compile(purescript.psc, paths.src.concat(paths.examples.ace.src), paths.examples.ace.options)
-        .pipe(browserify({}))
-        .pipe(gulp.dest(paths.examples.ace.dest));
-});
-
-gulp.task('examples', function(cb) {
-    runSequence('example-todo', 'example-counter', 'example-ajax', 'example-ace', cb);
-});
-
 gulp.task('make', function() {
     return compile(purescript.pscMake, paths.src, {})
         .pipe(gulp.dest(paths.dest))
@@ -164,5 +102,5 @@ gulp.task('docs', function() {
 });
 
 gulp.task('default', function(cb) {
-    runSequence('make', 'docs', 'examples', cb);
+    runSequence('make', 'docs', cb);
 });


### PR DESCRIPTION
This change makes it a bit easier to manage dependencies in the example projects, and also speeds up their builds, by moving each one into its own project, with its own `bower.json`. This also lets us move the `devDependency` on `purescript-ace` into the `ace/` directory.

I'd like to eventually add a `purescript-echarts` example, so I made this change to avoid any more dev dependencies.

@jdegoes Does this look ok?