### PR TITLE
Move versioning logic out of 'widget'

### DIFF
--- a/docs/Halogen-Component.md
+++ b/docs/Halogen-Component.md
@@ -54,7 +54,7 @@ A variant of `component` which creates a component with some internal, hidden in
 #### `widget`
 
 ``` purescript
-widget :: forall eff req res s m. (Functor m) => { destroy :: s -> HTMLElement -> Eff eff Unit, update :: req -> s -> HTMLElement -> Eff eff (Maybe HTMLElement), init :: (res -> Eff eff Unit) -> Eff eff { node :: HTMLElement, state :: s }, id :: String, name :: String } -> Component (Widget eff res) m req res
+widget :: forall eff req res ctx m. (Functor m) => { destroy :: ctx -> HTMLElement -> Eff eff Unit, update :: req -> ctx -> HTMLElement -> Eff eff (Maybe HTMLElement), init :: (res -> Eff eff Unit) -> Eff eff { node :: HTMLElement, context :: ctx }, id :: String, name :: String } -> Component (Widget eff res) m req res
 ```
 
 Construct a `Component` from a third-party widget.

--- a/docs/Halogen-Widgets.md
+++ b/docs/Halogen-Widgets.md
@@ -8,7 +8,7 @@ This module defines helper functions for working with third-party widgets.
 #### `widget`
 
 ``` purescript
-widget :: forall eff ref i s. { destroy :: s -> HTMLElement -> Eff eff Unit, update :: s -> HTMLElement -> Eff eff (Maybe HTMLElement), init :: (i -> Eff eff Unit) -> Eff eff { node :: HTMLElement, state :: s }, id :: String, name :: String, ref :: Int } -> V.Widget eff i
+widget :: forall eff ctx val res. { destroy :: ctx -> HTMLElement -> Eff eff Unit, update :: val -> val -> ctx -> HTMLElement -> Eff eff (Maybe HTMLElement), init :: (res -> Eff eff Unit) -> Eff eff { node :: HTMLElement, context :: ctx }, id :: String, name :: String, value :: val } -> V.Widget eff res
 ```
 
 Create a `VTree` from a third-party component (or _widget_), by providing a name, an ID, and three functions:

--- a/src/Halogen/HTML/Widget.purs
+++ b/src/Halogen/HTML/Widget.purs
@@ -21,11 +21,17 @@ import qualified Halogen.Internal.VirtualDOM as V
 -- | - A finalizer function, which deallocates any necessary resources when the component is removed from the DOM.
 -- |
 -- | The three functions share a common piece of data of a hidden type `s`.
-widget :: forall eff ref i s. { ref     :: Int
-                              , name    :: String
-                              , id      :: String
-                              , init    :: (i -> Eff eff Unit) -> Eff eff { state :: s, node :: HTMLElement }
-                              , update  :: s -> HTMLElement -> Eff eff (Maybe HTMLElement)
-                              , destroy :: s -> HTMLElement -> Eff eff Unit
-                              } -> V.Widget eff i
-widget spec = runFn6 V.widget spec.ref spec.name spec.id spec.init (\s n -> toNullable <$> spec.update s n) spec.destroy
+widget :: forall eff ctx val res. { value   :: val
+                                  , name    :: String
+                                  , id      :: String
+                                  , init    :: (res -> Eff eff Unit) -> Eff eff { context :: ctx, node :: HTMLElement }
+                                  , update  :: val -> val -> ctx -> HTMLElement -> Eff eff (Maybe HTMLElement)
+                                  , destroy :: ctx -> HTMLElement -> Eff eff Unit
+                                  } -> V.Widget eff res
+widget spec = runFn6 V.widget 
+                     spec.value 
+                     spec.name 
+                     spec.id 
+                     spec.init 
+                     (mkFn4 \v0 v1 ctx node -> toNullable <$> spec.update v0 v1 ctx node) 
+                     (mkFn2 spec.destroy)


### PR DESCRIPTION
This change moves the versioning code, needed to fix the "multiple inputs" issue, out of `VirtualDOM.Internal` and into the `Component` module, the only place where it is used.

This should make it easier for widgets to implement their own custom diffing code. Now each widget contains:

- Its "context" `ctx`, created during `init` and passed to `update`.
- Its "value" `val`. In the `Component` module the value is the version, an `Int`, and we only update if the version increased. In general though, this could be used for more fine-grained diffing.

The high-level API hasn't changed apart from to rename `state` to `context`, since the state never really changed.

@jdegoes @garyb Could you please review?