### PR TITLE
Drop IsForeign from onInput

### DIFF
--- a/docs/Halogen-Forms.md
+++ b/docs/Halogen-Forms.md
@@ -26,7 +26,7 @@ Attach an event handler which will fire when a checkbox is checked or unchecked
 #### `onInput`
 
 ``` purescript
-onInput :: forall f value i. (Alternative f, IsForeign value) => (value -> EventHandler (f i)) -> H.Attr (f i)
+onInput :: forall f i. (Alternative f) => (String -> EventHandler (f i)) -> H.Attr (f i)
 ```
 
 Attach an event handler which will fire on input

--- a/src/Halogen/HTML/Events/Forms.purs
+++ b/src/Halogen/HTML/Events/Forms.purs
@@ -1,11 +1,11 @@
 -- | Convenience functions for working with form elements.
 
-module Halogen.HTML.Events.Forms 
+module Halogen.HTML.Events.Forms
   ( onValueChanged
   , onChecked
   , onInput
   ) where
-    
+
 import DOM
 
 import Data.Maybe
@@ -20,7 +20,7 @@ import Control.Alternative
 import Halogen.HTML.Events.Handler
 
 import qualified Halogen.HTML.Attributes as H
-  
+
 -- | Attach event handler to event ```key``` with getting ```prop``` field
 -- | as an argument of handler
 addForeignPropHandler :: forall f i value. (Alternative f, IsForeign value) => String -> String -> (value -> EventHandler (f i)) -> H.Attr (f i)
@@ -42,5 +42,5 @@ onChecked :: forall f i. (Alternative f) => (Boolean -> EventHandler (f i)) -> H
 onChecked = addForeignPropHandler "change" "checked"
 
 -- | Attach an event handler which will fire on input
-onInput :: forall f value i. (Alternative f, IsForeign value) => (value -> EventHandler (f i)) -> H.Attr (f i)
+onInput :: forall f i. (Alternative f) => (String -> EventHandler (f i)) -> H.Attr (f i)
 onInput = addForeignPropHandler "input" "value"


### PR DESCRIPTION
`IsForeign` here is a bit misleading, as the value is always a string for this event. I've been tripped up several times trying to use `IsForeign` to cast the value to a number for me, but it won't ever do that as `IsForeign` reading only succeeds for prim values with the right runtime tag.

The same might be true for `onValueChanged`, but I'm not 100% certain.