### PR TITLE
Fixed "for" HTML attribute

### DIFF
--- a/src/Halogen/HTML/Attributes.purs
+++ b/src/Halogen/HTML/Attributes.purs
@@ -219,7 +219,7 @@ content :: forall i. String -> Attr i
 content = attr $ attributeName "content"
 
 for :: forall i. String -> Attr i
-for = attr $ attributeName "for"
+for = attr $ attributeName "htmlFor"
 
 height :: forall i. Number -> Attr i
 height = attr (attributeName "height") <<< show


### PR DESCRIPTION
The "for" smart constructor now uses the proper attributeName.