### PR TITLE
Svg support (WIP)

### DIFF
--- a/docs/Halogen-HTML.md
+++ b/docs/Halogen-HTML.md
@@ -1804,11 +1804,22 @@ data HandlerF i fields
 The data which represents a typed event handler, hidden inside an existential package in
 the `Attr` type.
 
+#### `AttrNS`
+
+``` purescript
+data AttrNS
+  = SvgNS 
+  | XmlNS 
+  | XlinkNS 
+```
+
+
 #### `Attr`
 
 ``` purescript
 data Attr i
-  = Attr (Exists AttrF)
+  = Attr (Maybe AttrNS) (Exists AttrF)
+  | Prop (Exists AttrF)
   | Handler (ExistsR (HandlerF i))
   | Initializer i
   | Finalizer i

--- a/src/Halogen/HTML/Renderer/String.purs
+++ b/src/Halogen/HTML/Renderer/String.purs
@@ -19,8 +19,12 @@ import qualified Halogen.HTML.Attributes as A
 import Halogen.HTML.Events.Types 
 
 renderAttr :: forall i. A.Attr i -> Maybe String
-renderAttr (A.Attr e) = runExists (\(A.AttrF f key value) -> Just $ A.runAttributeName key <> "=\"" <> f key value <> "\"") e
+renderAttr (A.Attr _ e) = renderExistsAttrF e
+renderAttr (A.Prop e) = renderExistsAttrF e
 renderAttr _ = Nothing
+
+renderExistsAttrF :: Exists A.AttrF -> Maybe String
+renderExistsAttrF e = runExists (\(A.AttrF f key value) -> Just $ A.runAttributeName key <> "=\"" <> f key value <> "\"") e
 
 -- | Render a HTML document as a `String`, usually for testing purposes.
 renderHTMLToString :: forall i. H.HTML i -> String

--- a/src/Halogen/HTML/Renderer/VirtualDOM.purs
+++ b/src/Halogen/HTML/Renderer/VirtualDOM.purs
@@ -5,6 +5,7 @@ module Halogen.HTML.Renderer.VirtualDOM
 import Data.Array (map)
 import Data.Function    
 import Data.Foldable (for_, foldMap)
+import Data.Maybe
 import Data.Monoid
 import Data.Exists
 
@@ -18,8 +19,10 @@ import Halogen.HTML.Events.Types
 import Halogen.HTML.Events.Handler
 import Halogen.Internal.VirtualDOM
       
-renderAttr :: forall i eff. (i -> Eff eff Unit) -> A.Attr i -> Props
-renderAttr _  (A.Attr e) = runExists (\(A.AttrF _ key value) -> runFn2 prop (A.runAttributeName key) value) e
+renderAttr :: forall i eff. (i -> Eff eff Unit) -> A.Attr i -> VProps
+renderAttr _  (A.Attr Nothing e) = runExists (\(A.AttrF _ key value) -> runFn2 attrVProp (A.runAttributeName key) value) e
+renderAttr _  (A.Attr (Just ns) e) = runExists (\(A.AttrF _ key value) -> runFn3 nsAttrVProp (A.attrNSRaw ns) (A.runAttributeName key) value) e
+renderAttr _  (A.Prop e) = runExists (\(A.AttrF _ key value) -> runFn2 vprop (A.runAttributeName key) value) e
 renderAttr dr (A.Handler e) = A.runExistsR (\(A.HandlerF name k) ->
   runFn2 handlerVProp (A.runEventName name) \ev -> do
     a <- unsafeInterleaveEff $ runEventHandler ev (k ev)

--- a/src/Halogen/HTML/Renderer/VirtualDOM.purs
+++ b/src/Halogen/HTML/Renderer/VirtualDOM.purs
@@ -21,11 +21,11 @@ import Halogen.Internal.VirtualDOM
 renderAttr :: forall i eff. (i -> Eff eff Unit) -> A.Attr i -> Props
 renderAttr _  (A.Attr e) = runExists (\(A.AttrF _ key value) -> runFn2 prop (A.runAttributeName key) value) e
 renderAttr dr (A.Handler e) = A.runExistsR (\(A.HandlerF name k) ->
-  runFn2 handlerProp (A.runEventName name) \ev -> do
+  runFn2 handlerVProp (A.runEventName name) \ev -> do
     a <- unsafeInterleaveEff $ runEventHandler ev (k ev)
     dr a) e
-renderAttr dr (A.Initializer i) = initProp (dr i)
-renderAttr dr (A.Finalizer i) = finalizerProp (dr i)
+renderAttr dr (A.Initializer i) = initVProp (dr i)
+renderAttr dr (A.Finalizer i) = finalizerVProp (dr i)
 
 -- | Render a `HTML` document to a virtual DOM node
 -- |

--- a/src/Halogen/Internal/VirtualDOM.purs
+++ b/src/Halogen/Internal/VirtualDOM.purs
@@ -4,12 +4,14 @@
 module Halogen.Internal.VirtualDOM
   ( VTree()
   , Patch()
-  , Props()
-  , emptyProps
-  , prop
-  , handlerProp
-  , initProp
-  , finalizerProp
+  , VProps()
+  , emptyVProps
+  , vprop
+  , attrVProp
+  , nsAttrVProp
+  , handlerVProp
+  , initVProp
+  , finalizerVProp
   , createElement
   , diff
   , patch
@@ -36,10 +38,10 @@ data VTree
 data Patch
 
 -- | Property collections
-data Props
+data VProps
 
-foreign import emptyProps
-  "var emptyProps = {}" :: Props
+foreign import emptyVProps
+  "var emptyVProps = {}" :: VProps
 
 -- | Create a property from a key/value pair.
 -- |
@@ -48,9 +50,9 @@ foreign import emptyProps
 -- |
 -- | Users should use caution when creating custom attributes, and understand how they will
 -- | be added to the DOM here.
-foreign import prop
+foreign import vprop
   """
-  function prop(key, value) {
+  function vprop(key, value) {
     var props = {};
     props[key] = value;
     return props;
@@ -58,9 +60,9 @@ foreign import prop
   """ :: forall value. Fn2 String value Props
 
 -- | Create a property from an event handler
-foreign import handlerProp
+foreign import handlerVProp
   """
-  function handlerProp(key, f) {
+  function handlerVProp(key, f) {
     var props = {};
     var Hook = function () {};
     Hook.prototype.callback = function (e) {
@@ -75,12 +77,12 @@ foreign import handlerProp
     props['halogen-hook-' + key] = new Hook(f);
     return props;
   }
-  """ :: forall eff event. Fn2 String (event -> Eff eff Unit) Props
+  """ :: forall eff event. Fn2 String (event -> Eff eff Unit) VProps
 
 -- | Create a property from an initializer
-foreign import initProp
+foreign import initVProp
   """
-  function initProp(f) {
+  function initVProp(f) {
     var props = {};
     var Hook = function () {};
     Hook.prototype.hook = function (node, prop, prev) {
@@ -91,12 +93,12 @@ foreign import initProp
     props['halogen-init'] = new Hook(f);
     return props;
   }
-  """ :: forall eff. Eff eff Unit -> Props
+  """ :: forall eff. Eff eff Unit -> VProps
 
 -- | Create a property from an finalizer
-foreign import finalizerProp
+foreign import finalizerVProp
   """
-  function finalizerProp(f) {
+  function finalizerVProp(f) {
     var props = {};
     var Hook = function () {};
     Hook.prototype.hook = function () { };
@@ -106,11 +108,11 @@ foreign import finalizerProp
     props['halogen-finalizer'] = new Hook(f);
     return props;
   }
-  """ :: forall eff. Eff eff Unit -> Props
+  """ :: forall eff. Eff eff Unit -> VProps
 
-foreign import concatProps
+foreign import concatVProps
   """
-  function concatProps(p1, p2) {
+  function concatVProps(p1, p2) {
     var props = {};
     for (var key in p1) {
       props[key] = p1[key];
@@ -120,13 +122,13 @@ foreign import concatProps
     }
     return props;
   }
-  """ :: Fn2 Props Props Props
+  """ :: Fn2 VProps VProps VProps
 
-instance semigroupProps :: Semigroup Props where
-  (<>) = runFn2 concatProps
+instance semigroupVProps :: Semigroup VProps where
+  (<>) = runFn2 concatVProps
 
-instance monoidProps :: Monoid Props where
-  mempty = emptyProps
+instance monoidVProps :: Monoid VProps where
+  mempty = emptyVProps
 
 -- | Create a DOM node from a virtual DOM tree
 foreign import createElement
@@ -207,4 +209,4 @@ foreign import vnode
       };
     };
   }());
-  """ :: String -> Props -> [VTree] -> VTree
+  """ :: String -> VProps -> [VTree] -> VTree

--- a/src/Halogen/Internal/VirtualDOM.purs
+++ b/src/Halogen/Internal/VirtualDOM.purs
@@ -233,7 +233,7 @@ foreign import vnode
           if (name === 'input' && props.value !== undefined) {
             props.value = new SoftSetHook(props.value);
           }
-          return new VirtualNode(name, props, children, attr.key);
+          return new VirtualNode(name, props, children, attr.key, attr.namespace);
         };
       };
     };

--- a/src/Halogen/SVG.purs
+++ b/src/Halogen/SVG.purs
@@ -1,0 +1,35 @@
+module Halogen.SVG
+  ( svgElement
+  , svg
+  , circle
+  , cx
+  , cy
+  , r
+  , fill
+  ) where
+
+import qualified Halogen.HTML as H
+import qualified Halogen.HTML.Attributes as A
+
+svgNS = A.prop (A.attributeName "namespace") "http://www.w3.org/2000/svg"
+
+svgElement :: forall i. H.TagName -> [A.Attr i] -> [H.HTML i] -> H.HTML i
+svgElement tagName attrs = H.Element tagName (svgNS : attrs)
+
+svg :: forall i. [A.Attr i] -> [H.HTML i] -> H.HTML i
+svg = svgElement (H.tagName "svg")
+
+circle :: forall i. [A.Attr i] -> [H.HTML i] -> H.HTML i
+circle = svgElement (H.tagName "circle")
+
+cx :: forall i. String -> A.Attr i
+cx = A.attr $ A.attributeName "cx"
+
+cy :: forall i. String -> A.Attr i
+cy = A.attr $ A.attributeName "cy"
+
+r :: forall i. String -> A.Attr i
+r = A.attr $ A.attributeName "r"
+
+fill :: forall i. String -> A.Attr i
+fill = A.attr $ A.attributeName "fill"

--- a/src/Halogen/SVG.purs
+++ b/src/Halogen/SVG.purs
@@ -1,12 +1,15 @@
 module Halogen.SVG
-  ( svgElement
-  , svg
-  , circle
-  , cx
-  , cy
-  , r
-  , fill
-  ) where
+  -- ( svgElement
+  -- , svg
+  -- , circle
+
+  -- , viewBox
+  -- , cx
+  -- , cy
+  -- , r
+  -- , fill
+  -- )
+  where
 
 import qualified Halogen.HTML as H
 import qualified Halogen.HTML.Attributes as A
@@ -22,14 +25,30 @@ svg = svgElement (H.tagName "svg")
 circle :: forall i. [A.Attr i] -> [H.HTML i] -> H.HTML i
 circle = svgElement (H.tagName "circle")
 
+g :: forall i. [A.Attr i] -> [H.HTML i] -> H.HTML i
+g = svgElement (H.tagName "g")
+
+path :: forall i. [A.Attr i] -> [H.HTML i] -> H.HTML i
+path = svgElement (H.tagName "path")
+
+
 cx :: forall i. String -> A.Attr i
 cx = A.attr $ A.attributeName "cx"
 
 cy :: forall i. String -> A.Attr i
 cy = A.attr $ A.attributeName "cy"
 
-r :: forall i. String -> A.Attr i
-r = A.attr $ A.attributeName "r"
+d :: forall i. String -> A.Attr i
+d = A.attr $ A.attributeName "d"
 
 fill :: forall i. String -> A.Attr i
 fill = A.attr $ A.attributeName "fill"
+
+r :: forall i. String -> A.Attr i
+r = A.attr $ A.attributeName "r"
+
+transform :: forall i. String -> A.Attr i
+transform = A.attr $ A.attributeName "transform"
+
+viewBox :: forall i. String -> A.Attr i
+viewBox = A.attr $ A.attributeName "viewBox"


### PR DESCRIPTION
:warning: _Not ready for merge_ :warning: 

This is a working POC, following the proposed plan in #133. 

Uncertainties:

  - In `Halogen.Internal.VirtualDOM`, things dealing with `prop` and `fooProp` are now `vprop` and `fooVProp`. This avoids conflict between `Halogen.HTML.Attributes.prop` and (previously) `Halogen.Internal.VirtualDOM.prop`.
    - Is this necessary? It seemed like the thing to do to me.
    - Should it go further, and prefix _everything_ in `Halogen.Internal.VirtualDOM` with 'v'? Things like `vtree`, `vnode`, and `vtext` are prefixed, but `diff`, `patch`, and `createElement` still aren't.
  - The new `Prop` constructor just copies `Exists AttrF` from `Attr`, which I assume is fine since it's the same shape, and may change soon anyway with #111.
  - The stuff so far in `Halogen.SVG` just use strings directly in attributes. I imagine this is ok for a first pass, maybe revisit when that module is more complete.

What's left to do:

  - [ ] change all (most?) of the Attrs in `Halogen.HTML.Attributes` from using `attr` to using `prop` now (since the old `attr` behaves like the new `prop`).
  - [ ] flesh out `Halogen.SVG` elements and attributes.
  - [ ] docs