### PR TITLE
Fix due to purescript-dom effect type change

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "purescript-aff-coroutines": "^0.2.0",
     "purescript-const": "^0.5.0",
-    "purescript-dom": "^0.2.1",
+    "purescript-dom": "^0.2.3",
     "purescript-foreign": "^0.7.0",
     "purescript-free": "^0.7.0",
     "purescript-maps": "^0.5.0",

--- a/src/Halogen/Util.purs
+++ b/src/Halogen/Util.purs
@@ -23,7 +23,7 @@ appendToBody :: forall m eff. (MonadEff (dom :: DOM | eff) m) => HTMLElement -> 
 appendToBody e = liftEff $ do
   addEventListener load (eventListener onLoad) false <<< windowToEventTarget =<< window
   where
-  onLoad :: Event -> Eff (dom :: DOM) Unit
+  onLoad :: forall eff. Event -> Eff (dom :: DOM | eff) Unit
   onLoad _ = do
     b <- toMaybe <$> ((body <=< document) =<< window)
     case b of


### PR DESCRIPTION
Effects in type of event listener stuff used in `onload` changed in [0.2.3](https://github.com/purescript-contrib/purescript-dom/releases/tag/v0.2.3)