### PR TITLE
Memoize children and batch state updates

### DIFF
--- a/examples/ace/src/Main.purs
+++ b/examples/ace/src/Main.purs
@@ -49,7 +49,7 @@ container = component' render eval peek
            , H.p_ [ H.text ("Current text: " ++ text) ]
            ]
 
-  eval :: Eval Input State Input (QueryF State AceState AceInput (Aff (AceEffects eff)) AceSlot p)
+  eval :: EvalP Input State AceState Input AceInput (Aff (AceEffects eff)) AceSlot p
   eval (ClearText next) = do
     query (AceSlot "test-ace") (action $ ChangeText "")
     pure next

--- a/examples/components/src/Main.purs
+++ b/examples/components/src/Main.purs
@@ -45,7 +45,7 @@ uiContainer = component render eval
                   ]
            ]
 
-  eval :: Eval Input State Input (QueryF State TickState TickInput g TickSlot p)
+  eval :: Eval Input State Input (QueryF State TickState Input TickInput g TickSlot p)
   eval (ReadTicks next) = do
     a <- query (TickSlot "A") (request GetTick)
     b <- query (TickSlot "B") (request GetTick)

--- a/examples/multi-component/src/Main.purs
+++ b/examples/multi-component/src/Main.purs
@@ -55,7 +55,7 @@ parent = component render eval
     , H.button [ E.onClick (E.input_ ReadStates) ] [ H.text "Read states" ]
     ]
 
-  eval :: Eval Input State Input (QueryF State ChildStates ChildInputs g ChildSlots p)
+  eval :: Eval Input State Input (QueryF State ChildStates Input ChildInputs g ChildSlots p)
   eval (ReadStates next) = do
     a <- query' cpA SlotA (request GetStateA)
     b <- query' cpB SlotB (request GetStateB)

--- a/examples/todo/src/Component/List.purs
+++ b/examples/todo/src/Component/List.purs
@@ -41,7 +41,7 @@ list = component' render eval peek
            , H.p_ [ H.text $ show st.numCompleted ++ " / " ++ show (length st.tasks) ++ " complete" ]
            ]
 
-  eval :: Eval ListInput State ListInput (QueryF State Task TaskInput g ListSlot p)
+  eval :: Eval ListInput State ListInput (QueryF State Task ListInput TaskInput g ListSlot p)
   eval (NewTask next) = do
     modify addTask
     pure next

--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -3,6 +3,7 @@ module Halogen.Component
   , Component()
   , Render()
   , Eval()
+  , EvalP()
   , Peek()
   , PeekP()
   , renderComponent
@@ -57,7 +58,7 @@ import qualified Data.Maybe.Unsafe as U
 
 import Halogen.Component.ChildPath (ChildPath(), injState, injQuery, injSlot, prjState, prjQuery, prjSlot)
 import Halogen.HTML.Core (HTML(..), fillSlot)
-import Halogen.Query (HalogenF(), get)
+import Halogen.Query (HalogenF(), get, modify)
 import Halogen.Query.StateF (StateF(), mapState)
 import Halogen.Query.SubscribeF (SubscribeF(), subscribeN, remapSubscribe, hoistSubscribe)
 
@@ -89,9 +90,11 @@ type Render s f p = s -> HTML p (f Unit)
 -- | component algebra.
 type Eval i s f g = Natural i (Free (HalogenF s f g))
 
+type EvalP i s s' f f' g p p' = Eval i s f (QueryF s s' f f' g p p')
+
 -- | A type alias for a component `peek` function that observes inputs to child
 -- | components.
-type Peek s s' f f' g p p' = PeekP s f (QueryF s s' f' g p p') (ChildF p f')
+type Peek s s' f f' g p p' = PeekP s f (QueryF s s' f f' g p p') (ChildF p f')
 
 -- | A lower level form of the `Peek` type synonym, used internally.
 type PeekP s f g o = forall a. o a -> Free (HalogenF s f g) Unit
@@ -118,7 +121,7 @@ component r q = Component { render: CMS.gets r, eval: q, peek: const (pure unit)
 -- | Builds a new [`ComponentP`](#componentp) from a [`Render`](#render),
 -- | [`Eval`](#eval), and [`Peek`](#peek) function. This is used in cases where
 -- | defining a parent component that needs to observe inputs to its children.
-component' :: forall s s' f f' g p p'. Render s f p -> Eval f s f (QueryF s s' f' g p p') -> Peek s s' f f' g p p' -> ParentComponentP s s' f f' g p p'
+component' :: forall s s' f f' g p p'. Render s f p -> Eval f s f (QueryF s s' f f' g p p') -> Peek s s' f f' g p p' -> ParentComponentP s s' f f' g p p'
 component' r q p = Component { render: CMS.gets r, eval: q, peek: p }
 
 -- | A type synonym for a component combined with its state. This is used when
@@ -137,34 +140,35 @@ createChild' i c s = Tuple (transform i c) (injState i s)
 -- | A type alias used to simplify the type signature for a `Component s f g p`
 -- | that is intended to have components of type `Component s' f' g p'`
 -- | installed into it.
-type ParentComponent s s' f f' g p p' = Component s f (QueryF s s' f' g p p') p
+type ParentComponent s s' f f' g p p' = Component s f (QueryF s s' f f' g p p') p
 
 -- | A type alias similar to `ParentComponent`, but for components that `peek`
 -- | on their children.
-type ParentComponentP s s' f f' g p p' = ComponentP s f (QueryF s s' f' g p p') (ChildF p f') p
+type ParentComponentP s s' f f' g p p' = ComponentP s f (QueryF s s' f f' g p p') (ChildF p f') p
 
 -- | A type alias use to simplify the type signature for a `Component s f g p`
 -- | that has had components of type `Component s' f' g p'` installed into it.
-type InstalledComponent s s' f f' g p p' = Component (InstalledState s s' f' g p p') (Coproduct f (ChildF p f')) g p'
+type InstalledComponent s s' f f' g p p' = Component (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g p'
 
 -- | The type used by component containers for their state where `s` is the
 -- | state local to the container, `p` is the type of slot used by the
 -- | container, and the remaining parameters are the type variables for the
 -- | child components.
-type InstalledState s s' f' g p p' =
+type InstalledState s s' f f' g p p' =
   { parent   :: s
   , children :: M.Map p (ChildState s' f' g p')
+  , memo     :: M.Map p (HTML p' (Coproduct f (ChildF p f') Unit))
   }
 
 -- | Creates an initial `InstalledState` value for a component container based
 -- | on a state value for the container.
-installedState :: forall s s' f' g p p'. (Ord p) => s -> InstalledState s s' f' g p p'
-installedState = { parent: _, children: M.empty }
+installedState :: forall s s' f f' g p p'. (Ord p) => s -> InstalledState s s' f f' g p p'
+installedState = { parent: _, children: M.empty, memo: M.empty }
 
 -- | An intermediate algebra that parent components "produce" from their `eval`
 -- | and `peek` functions. This takes the place of `g` when compared to a leaf
 -- | (non-parent) component.
-type QueryF s s' f' g p p' = Free (HalogenF (InstalledState s s' f' g p p') (ChildF p f') g)
+type QueryF s s' f f' g p p' = Free (HalogenF (InstalledState s s' f f' g p p') (ChildF p f') g)
 
 -- | An intermediate algebra used to associate values from a child component's
 -- | algebra with the slot the component was installed into.
@@ -178,16 +182,16 @@ instance functorChildF :: (Functor f) => Functor (ChildF p f) where
 query :: forall s s' f f' g p p' i. (Functor g, Ord p)
       => p
       -> f' i
-      -> Free (HalogenF s f (QueryF s s' f' g p p')) (Maybe i)
+      -> Free (HalogenF s f (QueryF s s' f f' g p p')) (Maybe i)
 query p q = liftQuery (mkQuery p q)
 
 -- | A version of [`query`](#query) for use when a parent component has multiple
 -- | types of child component.
-query' :: forall s s' s'' f f' f'' g p p' p'' i. (Functor g, Ord p)
-      => ChildPath s'' s' f'' f' p'' p
-      -> p''
-      -> f'' i
-      -> Free (HalogenF s f (QueryF s s' f' g p p')) (Maybe i)
+query' :: forall s s' s'' f f' f'' g p p' p'' i. (Functor g, Ord p')
+       => ChildPath s s' f f' p p'
+       -> p
+       -> f i
+       -> Free (HalogenF s'' f'' (QueryF s'' s' f'' f' g p' p'')) (Maybe i)
 query' i p q = liftQuery (mkQuery' i p q)
 
 -- | Creates a query for a child component where `p` is the slot the component
@@ -195,10 +199,10 @@ query' i p q = liftQuery (mkQuery' i p q)
 -- |
 -- | If a component is not found for the slot the result of the query
 -- | will be `Nothing`.
-mkQuery :: forall s s' f' p p' g i. (Functor g, Ord p)
+mkQuery :: forall s s' f f' p p' g i. (Functor g, Ord p)
       => p
       -> f' i
-      -> QueryF s s' f' g p p' (Maybe i)
+      -> QueryF s s' f f' g p p' (Maybe i)
 mkQuery p q = do
   st <- get
   case M.lookup p st.children of
@@ -207,17 +211,17 @@ mkQuery p q = do
 
 -- | A version of [`mkQuery`](#mkQuery) for use when a parent component has
 -- | multiple types of child component.
-mkQuery' :: forall s s' s'' f f' g p p' p'' i. (Functor g, Ord p')
-         => ChildPath s'' s' f f' p p'
+mkQuery' :: forall s s' s'' f f' f'' g p p' p'' i. (Functor g, Ord p')
+         => ChildPath s s' f f' p p'
          -> p
          -> f i
-         -> QueryF s s' f' g p' p'' (Maybe i)
+         -> QueryF s'' s' f'' f' g p' p'' (Maybe i)
 mkQuery' i p q = mkQuery (injSlot i p) (injQuery i q)
 
 -- | Lifts a value in the `QueryF` algebra into the monad used by a component's
 -- | `eval` function.
 liftQuery :: forall s s' f f' g p p'. (Functor g)
-          => Eval (QueryF s s' f' g p p') s f (QueryF s s' f' g p p')
+          => Eval (QueryF s s' f f' g p p') s f (QueryF s s' f f' g p p')
 liftQuery qf = liftF (right (right qf))
 
 -- | Installs children into a parent component by using a function that produces
@@ -228,7 +232,7 @@ install :: forall s s' f f' g p p'. (Plus g, Ord p)
         -> InstalledComponent s s' f f' g p p'
 install c f = Component { render: render c f, eval: eval, peek: const (pure unit) }
   where
-  eval :: Eval (Coproduct f (ChildF p f')) (InstalledState s s' f' g p p') (Coproduct f (ChildF p f')) g
+  eval :: Eval (Coproduct f (ChildF p f')) (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
   eval = coproduct (queryParent c) queryChild
 
 -- | A version of [`install`](#install) for use with parent components that
@@ -239,72 +243,79 @@ install' :: forall s s' f f' g p p'. (Plus g, Ord p)
         -> InstalledComponent s s' f f' g p p'
 install' c f = Component { render: render c f, eval: eval, peek: const (pure unit) }
   where
-  eval :: Eval (Coproduct f (ChildF p f')) (InstalledState s s' f' g p p') (Coproduct f (ChildF p f')) g
+  eval :: Eval (Coproduct f (ChildF p f')) (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
   eval = coproduct (queryParent c) (\q -> queryChild q <* peek q)
 
-  peek :: PeekP (InstalledState s s' f' g p p') (Coproduct f (ChildF p f')) g (ChildF p f')
+  peek :: PeekP (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g (ChildF p f')
   peek q =
     let runSubscribeF' = runSubscribeF (queryParent c)
     in foldFree (coproduct mergeParentStateF (coproduct runSubscribeF' liftChildF)) (peekComponent c q)
 
-mapStateFParent :: forall s s' f' g p p'. Natural (StateF s) (StateF (InstalledState s s' f' g p p'))
-mapStateFParent = mapState (_.parent) (\f st -> { parent: f st.parent, children: st.children })
+mapStateFParent :: forall s s' f f' g p p'. Natural (StateF s) (StateF (InstalledState s s' f f' g p p'))
+mapStateFParent = mapState (_.parent) (\f st -> st { parent = f st.parent })
 
-mapStateFChild :: forall s s' f' g p p'. (Ord p) => p -> Natural (StateF s') (StateF (InstalledState s s' f' g p p'))
+mapStateFChild :: forall s s' f f' g p p'. (Ord p) => p -> Natural (StateF s') (StateF (InstalledState s s' f f' g p p'))
 mapStateFChild p = mapState (\st -> U.fromJust $ snd <$> M.lookup p st.children)
-                            (\f st -> { parent: st.parent, children: M.update (Just <<< rmap f) p st.children })
+                            (\f st -> { parent: st.parent, children: M.update (Just <<< rmap f) p st.children, memo: st.memo })
 
 render :: forall s s' f f' g o p p'. (Ord p)
-       => ComponentP s f (QueryF s s' f' g p p') o p
+       => ComponentP s f (QueryF s s' f f' g p p') o p
        -> (p -> ChildState s' f' g p')
-       -> State (InstalledState s s' f' g p p') (HTML p' ((Coproduct f (ChildF p f')) Unit))
+       -> State (InstalledState s s' f f' g p p') (HTML p' ((Coproduct f (ChildF p f')) Unit))
 render c f = do
     st <- CMS.get
     case renderComponent c st.parent of
       Tuple html s -> do
         -- Empty the state so that we don't keep children that are no longer
         -- being rendered...
-        CMS.put { parent: s, children: M.empty :: M.Map p (ChildState s' f' g p') }
+        CMS.put { parent: s, children: M.empty :: M.Map p (ChildState s' f' g p'), memo: M.empty :: M.Map p (HTML p' (Coproduct f (ChildF p f') Unit)) }
         -- ...but then pass through the old state so we can lookup child
         -- components that are being re-rendered
         fillSlot (renderChild st) left html
 
   where
 
-  renderChild :: InstalledState s s' f' g p p'
+  renderChild :: InstalledState s s' f f' g p p'
               -> p
-              -> State (InstalledState s s' f' g p p') (HTML p' ((Coproduct f (ChildF p f')) Unit))
-  renderChild st p = renderChild' st p $ fromMaybe' (\_ -> f p) (M.lookup p st.children)
+              -> State (InstalledState s s' f f' g p p') (HTML p' ((Coproduct f (ChildF p f')) Unit))
+  renderChild st p =
+    let childState = M.lookup p st.children
+    in case M.lookup p st.memo of
+      Just html -> do
+        CMS.modify (\st' -> { parent: st'.parent, children: M.alter (const childState) p st'.children, memo: M.insert p html st'.memo } :: InstalledState s s' f f' g p p')
+        pure html
+      Nothing -> renderChild' p $ fromMaybe' (\_ -> f p) childState
 
-  renderChild' :: InstalledState s s' f' g p p'
-               -> p
+  renderChild' :: p
                -> ChildState s' f' g p'
-               -> State (InstalledState s s' f' g p p') (HTML p' ((Coproduct f (ChildF p f')) Unit))
-  renderChild' st p (Tuple c s) = case renderComponent c s of
+               -> State (InstalledState s s' f f' g p p') (HTML p' ((Coproduct f (ChildF p f')) Unit))
+  renderChild' p (Tuple c s) = case renderComponent c s of
     Tuple html s' -> do
-      CMS.modify (\st -> st { children = M.insert p (Tuple c s') st.children })
+      CMS.modify (\st -> { parent: st.parent, children: M.insert p (Tuple c s') st.children, memo: st.memo } :: InstalledState s s' f f' g p p')
       pure $ right <<< ChildF p <$> html
 
 queryParent :: forall s s' f f' g o p p' q. (Functor g)
-            => ComponentP s f (QueryF s s' f' g p p') o q
-            -> Eval f (InstalledState s s' f' g p p') (Coproduct f (ChildF p f')) g
+            => ComponentP s f (QueryF s s' f f' g p p') o q
+            -> Eval f (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
 queryParent c q = foldFree (coproduct mergeParentStateF (coproduct (runSubscribeF (queryParent c)) liftChildF)) (queryComponent c q)
 
-mergeParentStateF :: forall s s' f f' g p p'. Eval (StateF s) (InstalledState s s' f' g p p') (Coproduct f (ChildF p f')) g
+mergeParentStateF :: forall s s' f f' g p p'. Eval (StateF s) (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
 mergeParentStateF = liftF <<< left <<< mapStateFParent
 
 runSubscribeF :: forall s s' f f' g p p'. (Functor g)
-              => Eval f (InstalledState s s' f' g p p') (Coproduct f (ChildF p f')) g
-              -> Eval (SubscribeF f (Free (HalogenF (InstalledState s s' f' g p p') (ChildF p f') g))) (InstalledState s s' f' g p p') (Coproduct f (ChildF p f')) g
+              => Eval f (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
+              -> Eval (SubscribeF f (Free (HalogenF (InstalledState s s' f f' g p p') (ChildF p f') g))) (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
 runSubscribeF queryParent' = subscribeN (forever $ lift <<< queryParent' =<< await) <<< hoistSubscribe liftChildF
 
 liftChildF :: forall s s' f f' g p p'. (Functor g)
-           => Eval (Free (HalogenF (InstalledState s s' f' g p p') (ChildF p f') g)) (InstalledState s s' f' g p p') (Coproduct f (ChildF p f')) g
+           => Eval (Free (HalogenF (InstalledState s s' f f' g p p') (ChildF p f') g)) (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
 liftChildF = mapF (coproduct left (right <<< coproduct (left <<< remapSubscribe right) right))
 
 queryChild :: forall s s' f f' g p p'. (Plus g, Ord p)
-           => Eval (ChildF p f') (InstalledState s s' f' g p p') (Coproduct f (ChildF p f')) g
-queryChild (ChildF p q) = mapF (coproduct left (right <<< coproduct (left <<< remapSubscribe right) right)) (mkQuery p q) >>= maybe empty' pure
+           => Eval (ChildF p f') (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
+queryChild (ChildF p q) = do
+  modify (\st -> { parent: st.parent, children: st.children, memo: M.delete p st.memo })
+  mapF (coproduct left (right <<< coproduct (left <<< remapSubscribe right) right)) (mkQuery p q) >>= maybe empty' pure
   where
   empty' :: forall s f g a. (Plus g) => Free (HalogenF s f g) a
   empty' = liftF (right (right empty))


### PR DESCRIPTION
Two changes here:

1. State modifications are now batched together so that rendering occurs either after the `Free HalogenF` has been fully processed, or when we switch from processing `StateF` to running the inner `Aff`. This means we render much less frequently now while preserving the property that running the inner `Aff` does not block rendering.
2. Child component HTML is now only re-rendered if the child has received a query since it was last rendered.

1 actually made the biggest difference here by far. 2 gives a micro improvement in the example I was testing with, but should have a more pronounced effect when children have complex HTML.