### PR TITLE
Support interpretation of a component's `g` type

### DIFF
--- a/docs/Halogen/Component.md
+++ b/docs/Halogen/Component.md
@@ -273,4 +273,13 @@ install' :: forall s s' f f' g p p'. (Plus g, Ord p) => ParentComponentP s s' f 
 A version of [`install`](#install) for use with parent components that
 `peek` on their children.
 
+#### `interpret`
+
+``` purescript
+interpret :: forall s f g g' p. (Functor g') => Natural g g' -> Component s f g p -> Component s f g' p
+```
+
+Changes the component's `g` type. A use case for this would be to interpret
+some `Free` monad as `Aff` so the component can be used with `runUI`.
+
 

--- a/docs/Halogen/Query.md
+++ b/docs/Halogen/Query.md
@@ -115,6 +115,15 @@ subscribe :: forall s f g. EventSource f g -> Free (HalogenF s f g) Unit
 Provides a way of having a component subscribe to an `EventSource` from
 within an `Eval` or `Peek` function.
 
+#### `liftH`
+
+``` purescript
+liftH :: forall a s f g. g a -> Free (HalogenF s f g) a
+```
+
+A convenience function for lifting a `g` value directly into
+`Free HalogenF` without the need to use `liftF $ right $ right $ ...`.
+
 #### `liftAff'`
 
 ``` purescript
@@ -134,5 +143,13 @@ liftEff' :: forall eff a s f g. (MonadEff eff g, Functor g) => Eff eff a -> Free
 A convenience function for lifting an `Eff` action directly into a
 `Free HalogenF` when there is a `MonadEff` instance for the current `g`,
 without the need to use `liftFI $ liftEff $ ...`.
+
+#### `hoistHalogenF`
+
+``` purescript
+hoistHalogenF :: forall s f g h. (Functor h) => Natural g h -> Natural (HalogenF s f g) (HalogenF s f h)
+```
+
+Changes the underlying `g` monad for a `HalogenF` value.
 
 

--- a/examples/interpret/.gitignore
+++ b/examples/interpret/.gitignore
@@ -1,0 +1,3 @@
+/dist/example.js
+/output
+/bower_components

--- a/examples/interpret/bower.json
+++ b/examples/interpret/bower.json
@@ -1,0 +1,7 @@
+{
+  "name": "interpret",
+  "private": true,
+  "dependencies": {
+    "purescript-halogen": "*"
+  }
+}

--- a/examples/interpret/dist/index.html
+++ b/examples/interpret/dist/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:foo="http://www.w3.org/2000/svg">
+  <head>
+    <title>Halogen Example - Interpret</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        max-width: 800px;
+        margin: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <script src="example.js"></script>
+  </body>
+</html>

--- a/examples/interpret/gulpfile.js
+++ b/examples/interpret/gulpfile.js
@@ -1,0 +1,40 @@
+/* jshint node: true */
+"use strict";
+
+var gulp = require("gulp");
+var purescript = require("gulp-purescript");
+var webpack = require("webpack-stream");
+
+var sources = [
+  "src/**/*.purs",
+  "bower_components/purescript-*/src/**/*.purs"
+];
+
+var foreigns = [
+  "bower_components/purescript-*/src/**/*.js"
+];
+
+gulp.task("make", function() {
+  return purescript.psc({ src: sources, ffi: foreigns });
+});
+
+gulp.task("prebundle", ["make"], function() {
+  return purescript.pscBundle({
+    src: "output/**/*.js",
+    output: "dist/example.js",
+    module: "Example.Intro",
+    main: "Example.Intro"
+  });
+});
+
+gulp.task("bundle", ["prebundle"], function () {
+  return gulp.src("dist/example.js")
+    .pipe(webpack({
+      resolve: { modulesDirectories: ["node_modules"] },
+      output: { filename: "example.js" }
+    }))
+    .pipe(gulp.dest("dist"));
+});
+
+gulp.task("default", ["bundle"]);
+

--- a/examples/interpret/src/Main.purs
+++ b/examples/interpret/src/Main.purs
@@ -1,0 +1,62 @@
+module Example.Intro where
+
+import Prelude
+
+import Control.Monad.Aff (Aff(), runAff)
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Console (CONSOLE())
+import Control.Monad.Eff.Exception (throwException)
+import Control.Monad.Free (Free(), liftF, foldFree)
+
+import Data.NaturalTransformation (Natural())
+
+import Halogen
+import Halogen.Util (appendToBody)
+import qualified Halogen.HTML.Indexed as H
+import qualified Halogen.HTML.Events.Indexed as E
+
+-- | The state of the application
+type State = { on :: Boolean }
+
+initialState :: State
+initialState = { on: false }
+
+-- | Inputs to the state machine
+data Input a = ToggleState a
+
+data OutputF a = Log String a
+
+type Output = Free OutputF
+
+output :: String -> Output Unit
+output msg = liftF (Log msg unit)
+
+ui :: forall p. Component State Input Output p
+ui = component render eval
+  where
+
+  render :: Render State Input p
+  render state = H.div_
+    [ H.h1_ [ H.text "Toggle Button" ]
+    , H.button [ E.onClick (E.input_ ToggleState) ]
+               [ H.text (if state.on then "On" else "Off") ]
+    ]
+
+  eval :: Eval Input State Input Output
+  eval (ToggleState next) = do
+    modify (\state -> { on: not state.on })
+    liftH $ output "State was toggled"
+    pure next
+
+ui' :: forall eff p. Component State Input (Aff (HalogenEffects (console :: CONSOLE | eff))) p
+ui' = interpret (foldFree evalOutput) ui
+  where
+  evalOutput :: Natural OutputF (Aff (HalogenEffects (console :: CONSOLE | eff)))
+  evalOutput (Log msg next) = do
+    Control.Monad.Aff.Console.log msg
+    pure next
+
+main :: Eff (HalogenEffects (console :: CONSOLE)) Unit
+main = runAff throwException (const (pure unit)) $ do
+  app <- runUI ui' initialState
+  appendToBody app.node


### PR DESCRIPTION
This will allow us to use a DSL to represent our UI's effectful operations and then specify how to interpret that independently.

/cc @jdegoes @jonsterling @beckyconning @cryogenian 