### PR TITLE
A few minor things to clean up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ script:
   - npm run example-ajax
   - npm run example-components
   - npm run example-counter
+  - npm run example-interpret
   - npm run example-intro
-  - npm run example-todo
   - npm run example-multi-component
+  - npm run example-todo

--- a/docs/Data/Injector.md
+++ b/docs/Data/Injector.md
@@ -28,6 +28,12 @@ inj :: forall a b. Injector a b -> a -> b
 prj :: forall a b. Injector a b -> b -> Maybe a
 ```
 
+#### `injI`
+
+``` purescript
+injI :: forall a. Injector a a
+```
+
 #### `injLE`
 
 ``` purescript

--- a/docs/Halogen/Component.md
+++ b/docs/Halogen/Component.md
@@ -57,7 +57,7 @@ A convenience variation on `Eval` for parent components.
 #### `Peek`
 
 ``` purescript
-type Peek s s' f f' g p p' = PeekP s f (QueryF s s' f f' g p p') (ChildF p f')
+type Peek i s s' f f' g p p' = PeekP i s f (QueryF s s' f f' g p p')
 ```
 
 A type alias for a component `peek` function that observes inputs to child
@@ -66,7 +66,7 @@ components.
 #### `PeekP`
 
 ``` purescript
-type PeekP s f g o = forall a. o a -> Free (HalogenF s f g) Unit
+type PeekP i s f g = forall a. i a -> Free (HalogenF s f g) Unit
 ```
 
 A lower level form of the `Peek` type synonym, used internally.
@@ -101,7 +101,7 @@ Builds a new [`Component`](#component) from a [`Render`](#render) and
 #### `component'`
 
 ``` purescript
-component' :: forall s s' f f' g p p'. Render s f p -> EvalP f s s' f f' g p p' -> Peek s s' f f' g p p' -> ParentComponentP s s' f f' g p p'
+component' :: forall s s' f f' g p p'. Render s f p -> EvalP f s s' f f' g p p' -> Peek (ChildF p f') s s' f f' g p p' -> ParentComponentP s s' f f' g p p'
 ```
 
 Builds a new [`ComponentP`](#componentp) from a [`Render`](#render),

--- a/docs/Halogen/Component.md
+++ b/docs/Halogen/Component.md
@@ -264,6 +264,15 @@ install :: forall s s' f f' g p p'. (Plus g, Ord p) => ParentComponent s s' f f'
 Installs children into a parent component by using a function that produces
 `ChildState` values for a given slot.
 
+#### `installWithState`
+
+``` purescript
+installWithState :: forall s s' f f' g p p'. (Plus g, Ord p) => ParentComponent s s' f f' g p p' -> (s -> p -> ChildState s' f' g p') -> InstalledComponent s s' f f' g p p'
+```
+
+A version of [`install`](#install) that gives us access to the parent's
+state while installing children.
+
 #### `install'`
 
 ``` purescript
@@ -272,6 +281,15 @@ install' :: forall s s' f f' g p p'. (Plus g, Ord p) => ParentComponentP s s' f 
 
 A version of [`install`](#install) for use with parent components that
 `peek` on their children.
+
+#### `installWithState'`
+
+``` purescript
+installWithState' :: forall s s' f f' g p p'. (Plus g, Ord p) => ParentComponentP s s' f f' g p p' -> (s -> p -> ChildState s' f' g p') -> InstalledComponent s s' f f' g p p'
+```
+
+A version of [`install'`](#install') that gives us access to the parent's
+state while installing children.
 
 #### `interpret`
 

--- a/docs/Halogen/Component/ChildPath.md
+++ b/docs/Halogen/Component/ChildPath.md
@@ -47,6 +47,14 @@ cpR :: forall s t f g p q. ChildPath s (Either t s) f (Coproduct g f) p (Either 
 A `ChildPath` that represents taking the right-hand choice for each of a
 component's `Either` and `Coproduct`s choices.
 
+#### `cpI`
+
+``` purescript
+cpI :: forall s f p. ChildPath s s f f p p
+```
+
+An identity `ChildPath`.
+
 #### `injState`
 
 ``` purescript

--- a/docs/Halogen/Driver.md
+++ b/docs/Halogen/Driver.md
@@ -13,7 +13,7 @@ query has been fulfilled.
 #### `runUI`
 
 ``` purescript
-runUI :: forall s f eff o. ComponentP s f (Aff (HalogenEffects eff)) o Void -> s -> Aff (HalogenEffects eff) { node :: HTMLElement, driver :: Driver f eff }
+runUI :: forall s f eff. Component s f (Aff (HalogenEffects eff)) Void -> s -> Aff (HalogenEffects eff) { node :: HTMLElement, driver :: Driver f eff }
 ```
 
 Runs the top level UI component for a Halogen app, returning a generated

--- a/docs/Halogen/HTML/Events.md
+++ b/docs/Halogen/HTML/Events.md
@@ -12,13 +12,13 @@ type EventProp e i = (Event e -> EventHandler i) -> Prop i
 #### `input`
 
 ``` purescript
-input :: forall f a. (forall i. a -> i -> f i) -> a -> EventHandler (f Unit)
+input :: forall f a. (a -> Action f) -> a -> EventHandler (f Unit)
 ```
 
 #### `input_`
 
 ``` purescript
-input_ :: forall f a. (forall i. i -> f i) -> a -> EventHandler (f Unit)
+input_ :: forall f a. Action f -> a -> EventHandler (f Unit)
 ```
 
 #### `onAbort`

--- a/docs/Halogen/HTML/Events/Indexed.md
+++ b/docs/Halogen/HTML/Events/Indexed.md
@@ -3,223 +3,223 @@
 #### `IEventProp`
 
 ``` purescript
-type IEventProp ρ e i = (Event e -> EventHandler i) -> IProp ρ i
+type IEventProp r e i = (Event e -> EventHandler i) -> IProp r i
 ```
 
 #### `onAbort`
 
 ``` purescript
-onAbort :: forall ρ i. IEventProp (onAbort :: I | ρ) () i
+onAbort :: forall r i. IEventProp (onAbort :: I | r) () i
 ```
 
 #### `onBeforeUnload`
 
 ``` purescript
-onBeforeUnload :: forall ρ i. IEventProp (onBeforeUnload :: I | ρ) () i
+onBeforeUnload :: forall r i. IEventProp (onBeforeUnload :: I | r) () i
 ```
 
 #### `onError`
 
 ``` purescript
-onError :: forall ρ i. IEventProp (onError :: I | ρ) () i
+onError :: forall r i. IEventProp (onError :: I | r) () i
 ```
 
 #### `onHashChange`
 
 ``` purescript
-onHashChange :: forall ρ i. IEventProp (onHashChange :: I | ρ) () i
+onHashChange :: forall r i. IEventProp (onHashChange :: I | r) () i
 ```
 
 #### `onLoad`
 
 ``` purescript
-onLoad :: forall ρ i. IEventProp (onLoad :: I | ρ) () i
+onLoad :: forall r i. IEventProp (onLoad :: I | r) () i
 ```
 
 #### `onPageShow`
 
 ``` purescript
-onPageShow :: forall ρ i. IEventProp (onPageShow :: I | ρ) () i
+onPageShow :: forall r i. IEventProp (onPageShow :: I | r) () i
 ```
 
 #### `onPageHide`
 
 ``` purescript
-onPageHide :: forall ρ i. IEventProp (onPageHide :: I | ρ) () i
+onPageHide :: forall r i. IEventProp (onPageHide :: I | r) () i
 ```
 
 #### `onResize`
 
 ``` purescript
-onResize :: forall ρ i. IEventProp (onResize :: I | ρ) () i
+onResize :: forall r i. IEventProp (onResize :: I | r) () i
 ```
 
 #### `onScroll`
 
 ``` purescript
-onScroll :: forall ρ i. IEventProp (onScroll :: I | ρ) () i
+onScroll :: forall r i. IEventProp (onScroll :: I | r) () i
 ```
 
 #### `onUnload`
 
 ``` purescript
-onUnload :: forall ρ i. IEventProp (onUnload :: I | ρ) () i
+onUnload :: forall r i. IEventProp (onUnload :: I | r) () i
 ```
 
 #### `onChange`
 
 ``` purescript
-onChange :: forall ρ i. IEventProp (onChange :: I | ρ) () i
+onChange :: forall r i. IEventProp (onChange :: I | r) () i
 ```
 
 #### `onInput`
 
 ``` purescript
-onInput :: forall ρ i. IEventProp (onInput :: I | ρ) () i
+onInput :: forall r i. IEventProp (onInput :: I | r) () i
 ```
 
 #### `onInvalid`
 
 ``` purescript
-onInvalid :: forall ρ i. IEventProp (onInvalid :: I | ρ) () i
+onInvalid :: forall r i. IEventProp (onInvalid :: I | r) () i
 ```
 
 #### `onReset`
 
 ``` purescript
-onReset :: forall ρ i. IEventProp (onReset :: I | ρ) () i
+onReset :: forall r i. IEventProp (onReset :: I | r) () i
 ```
 
 #### `onSearch`
 
 ``` purescript
-onSearch :: forall ρ i. IEventProp (onSearch :: I | ρ) () i
+onSearch :: forall r i. IEventProp (onSearch :: I | r) () i
 ```
 
 #### `onSelect`
 
 ``` purescript
-onSelect :: forall ρ i. IEventProp (onSelect :: I | ρ) () i
+onSelect :: forall r i. IEventProp (onSelect :: I | r) () i
 ```
 
 #### `onSubmit`
 
 ``` purescript
-onSubmit :: forall ρ i. IEventProp (onSubmit :: I | ρ) () i
+onSubmit :: forall r i. IEventProp (onSubmit :: I | r) () i
 ```
 
 #### `onClick`
 
 ``` purescript
-onClick :: forall ρ i. IEventProp (onClick :: I | ρ) MouseEvent i
+onClick :: forall r i. IEventProp (onClick :: I | r) MouseEvent i
 ```
 
 #### `onContextMenu`
 
 ``` purescript
-onContextMenu :: forall ρ i. IEventProp (onContextMenu :: I | ρ) MouseEvent i
+onContextMenu :: forall r i. IEventProp (onContextMenu :: I | r) MouseEvent i
 ```
 
 #### `onDoubleClick`
 
 ``` purescript
-onDoubleClick :: forall ρ i. IEventProp (onDoubleClick :: I | ρ) MouseEvent i
+onDoubleClick :: forall r i. IEventProp (onDoubleClick :: I | r) MouseEvent i
 ```
 
 #### `onMouseDown`
 
 ``` purescript
-onMouseDown :: forall ρ i. IEventProp (onMouseDown :: I | ρ) MouseEvent i
+onMouseDown :: forall r i. IEventProp (onMouseDown :: I | r) MouseEvent i
 ```
 
 #### `onMouseLeave`
 
 ``` purescript
-onMouseLeave :: forall ρ i. IEventProp (onMouseLeave :: I | ρ) MouseEvent i
+onMouseLeave :: forall r i. IEventProp (onMouseLeave :: I | r) MouseEvent i
 ```
 
 #### `onMouseMove`
 
 ``` purescript
-onMouseMove :: forall ρ i. IEventProp (onMouseMove :: I | ρ) MouseEvent i
+onMouseMove :: forall r i. IEventProp (onMouseMove :: I | r) MouseEvent i
 ```
 
 #### `onMouseOver`
 
 ``` purescript
-onMouseOver :: forall ρ i. IEventProp (onMouseOver :: I | ρ) MouseEvent i
+onMouseOver :: forall r i. IEventProp (onMouseOver :: I | r) MouseEvent i
 ```
 
 #### `onMouseOut`
 
 ``` purescript
-onMouseOut :: forall ρ i. IEventProp (onMouseOut :: I | ρ) MouseEvent i
+onMouseOut :: forall r i. IEventProp (onMouseOut :: I | r) MouseEvent i
 ```
 
 #### `onMouseUp`
 
 ``` purescript
-onMouseUp :: forall ρ i. IEventProp (onMouseUp :: I | ρ) MouseEvent i
+onMouseUp :: forall r i. IEventProp (onMouseUp :: I | r) MouseEvent i
 ```
 
 #### `onKeyDown`
 
 ``` purescript
-onKeyDown :: forall ρ i. IEventProp (onKeyDown :: I | ρ) KeyboardEvent i
+onKeyDown :: forall r i. IEventProp (onKeyDown :: I | r) KeyboardEvent i
 ```
 
 #### `onKeyPress`
 
 ``` purescript
-onKeyPress :: forall ρ i. IEventProp (onKeyPress :: I | ρ) KeyboardEvent i
+onKeyPress :: forall r i. IEventProp (onKeyPress :: I | r) KeyboardEvent i
 ```
 
 #### `onKeyUp`
 
 ``` purescript
-onKeyUp :: forall ρ i. IEventProp (onKeyUp :: I | ρ) KeyboardEvent i
+onKeyUp :: forall r i. IEventProp (onKeyUp :: I | r) KeyboardEvent i
 ```
 
 #### `onBlur`
 
 ``` purescript
-onBlur :: forall ρ i. IEventProp (onBlur :: I | ρ) FocusEvent i
+onBlur :: forall r i. IEventProp (onBlur :: I | r) FocusEvent i
 ```
 
 #### `onFocus`
 
 ``` purescript
-onFocus :: forall ρ i. IEventProp (onFocus :: I | ρ) FocusEvent i
+onFocus :: forall r i. IEventProp (onFocus :: I | r) FocusEvent i
 ```
 
 #### `onFocusIn`
 
 ``` purescript
-onFocusIn :: forall ρ i. IEventProp (onFocusIn :: I | ρ) FocusEvent i
+onFocusIn :: forall r i. IEventProp (onFocusIn :: I | r) FocusEvent i
 ```
 
 #### `onFocusOut`
 
 ``` purescript
-onFocusOut :: forall ρ i. IEventProp (onFocusOut :: I | ρ) FocusEvent i
+onFocusOut :: forall r i. IEventProp (onFocusOut :: I | r) FocusEvent i
 ```
 
 #### `onValueChange`
 
 ``` purescript
-onValueChange :: forall ρ f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onChange :: I | ρ) (f Unit)
+onValueChange :: forall r f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onChange :: I | r) (f Unit)
 ```
 
 #### `onValueInput`
 
 ``` purescript
-onValueInput :: forall ρ f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onInput :: I | ρ) (f Unit)
+onValueInput :: forall r f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onInput :: I | r) (f Unit)
 ```
 
 #### `onChecked`
 
 ``` purescript
-onChecked :: forall ρ f. (Boolean -> EventHandler (f Unit)) -> IProp (checked :: I, onChange :: I | ρ) (f Unit)
+onChecked :: forall r f. (Boolean -> EventHandler (f Unit)) -> IProp (checked :: I, onChange :: I | r) (f Unit)
 ```
 
 

--- a/docs/Halogen/HTML/Properties/Indexed.md
+++ b/docs/Halogen/HTML/Properties/Indexed.md
@@ -7,16 +7,16 @@ unrefined versions.
 #### `IProp`
 
 ``` purescript
-type IProp (ρ :: # *) i = IProp ρ i
+type IProp (r :: # *) i = IProp r i
 ```
 
-The phantom row `ρ` can be thought of as a context which is synthesized in the
+The phantom row `r` can be thought of as a context which is synthesized in the
 course of constructing a refined HTML expression.
 
 #### `erase`
 
 ``` purescript
-erase :: forall ρ i. IProp ρ i -> Prop i
+erase :: forall r i. IProp r i -> Prop i
 ```
 
 The refined property can be erased into a normal one.
@@ -32,103 +32,103 @@ A dummy type to use in the phantom row.
 #### `key`
 
 ``` purescript
-key :: forall ρ i. String -> IProp (key :: I | ρ) i
+key :: forall r i. String -> IProp (key :: I | r) i
 ```
 
 #### `alt`
 
 ``` purescript
-alt :: forall ρ i. String -> IProp (alt :: I | ρ) i
+alt :: forall r i. String -> IProp (alt :: I | r) i
 ```
 
 #### `charset`
 
 ``` purescript
-charset :: forall ρ i. String -> IProp (charset :: I | ρ) i
+charset :: forall r i. String -> IProp (charset :: I | r) i
 ```
 
 #### `class_`
 
 ``` purescript
-class_ :: forall ρ i. ClassName -> IProp (class :: I | ρ) i
+class_ :: forall r i. ClassName -> IProp (class :: I | r) i
 ```
 
 #### `classes`
 
 ``` purescript
-classes :: forall ρ i. Array ClassName -> IProp (class :: I | ρ) i
+classes :: forall r i. Array ClassName -> IProp (class :: I | r) i
 ```
 
 #### `colSpan`
 
 ``` purescript
-colSpan :: forall ρ i. Int -> IProp (colSpan :: I | ρ) i
+colSpan :: forall r i. Int -> IProp (colSpan :: I | r) i
 ```
 
 #### `rowSpan`
 
 ``` purescript
-rowSpan :: forall ρ i. Int -> IProp (rowSpan :: I | ρ) i
+rowSpan :: forall r i. Int -> IProp (rowSpan :: I | r) i
 ```
 
 #### `for`
 
 ``` purescript
-for :: forall ρ i. String -> IProp (for :: I | ρ) i
+for :: forall r i. String -> IProp (for :: I | r) i
 ```
 
 #### `height`
 
 ``` purescript
-height :: forall ρ i. LengthLiteral -> IProp (height :: I | ρ) i
+height :: forall r i. LengthLiteral -> IProp (height :: I | r) i
 ```
 
 #### `width`
 
 ``` purescript
-width :: forall ρ i. LengthLiteral -> IProp (width :: I | ρ) i
+width :: forall r i. LengthLiteral -> IProp (width :: I | r) i
 ```
 
 #### `href`
 
 ``` purescript
-href :: forall ρ i. String -> IProp (href :: I | ρ) i
+href :: forall r i. String -> IProp (href :: I | r) i
 ```
 
 #### `id_`
 
 ``` purescript
-id_ :: forall ρ i. String -> IProp (id :: I | ρ) i
+id_ :: forall r i. String -> IProp (id :: I | r) i
 ```
 
 #### `name`
 
 ``` purescript
-name :: forall ρ i. String -> IProp (name :: I | ρ) i
+name :: forall r i. String -> IProp (name :: I | r) i
 ```
 
 #### `rel`
 
 ``` purescript
-rel :: forall ρ i. String -> IProp (rel :: I | ρ) i
+rel :: forall r i. String -> IProp (rel :: I | r) i
 ```
 
 #### `src`
 
 ``` purescript
-src :: forall ρ i. String -> IProp (src :: I | ρ) i
+src :: forall r i. String -> IProp (src :: I | r) i
 ```
 
 #### `target`
 
 ``` purescript
-target :: forall ρ i. String -> IProp (target :: I | ρ) i
+target :: forall r i. String -> IProp (target :: I | r) i
 ```
 
 #### `title`
 
 ``` purescript
-title :: forall ρ i. String -> IProp (title :: I | ρ) i
+title :: forall r i. String -> IProp (title :: I | r) i
 ```
 
 #### `InputType`
@@ -163,7 +163,7 @@ data InputType
 #### `inputType`
 
 ``` purescript
-inputType :: forall ρ i. InputType -> IProp (inputType :: I | ρ) i
+inputType :: forall r i. InputType -> IProp (inputType :: I | r) i
 ```
 
 #### `MenuType`
@@ -178,7 +178,7 @@ data MenuType
 #### `menuType`
 
 ``` purescript
-menuType :: forall ρ i. MenuType -> IProp (menuType :: I | ρ) i
+menuType :: forall r i. MenuType -> IProp (menuType :: I | r) i
 ```
 
 #### `MenuitemType`
@@ -193,7 +193,7 @@ data MenuitemType
 #### `menuitemType`
 
 ``` purescript
-menuitemType :: forall ρ i. MenuitemType -> IProp (menuitemType :: I | ρ) i
+menuitemType :: forall r i. MenuitemType -> IProp (menuitemType :: I | r) i
 ```
 
 #### `MediaType`
@@ -205,7 +205,7 @@ type MediaType = { type :: String, subtype :: String, parameters :: Array (Tuple
 #### `mediaType`
 
 ``` purescript
-mediaType :: forall ρ i. MediaType -> IProp (mediaType :: I | ρ) i
+mediaType :: forall r i. MediaType -> IProp (mediaType :: I | r) i
 ```
 
 #### `ButtonType`
@@ -220,7 +220,7 @@ data ButtonType
 #### `buttonType`
 
 ``` purescript
-buttonType :: forall ρ i. ButtonType -> IProp (buttonType :: I | ρ) i
+buttonType :: forall r i. ButtonType -> IProp (buttonType :: I | r) i
 ```
 
 #### `CaseType`
@@ -250,103 +250,103 @@ data OrderedListType
 #### `olType`
 
 ``` purescript
-olType :: forall ρ i. OrderedListType -> IProp (olType :: I | ρ) i
+olType :: forall r i. OrderedListType -> IProp (olType :: I | r) i
 ```
 
 #### `value`
 
 ``` purescript
-value :: forall ρ i. String -> IProp (value :: I | ρ) i
+value :: forall r i. String -> IProp (value :: I | r) i
 ```
 
 #### `disabled`
 
 ``` purescript
-disabled :: forall ρ i. Boolean -> IProp (disabled :: I | ρ) i
+disabled :: forall r i. Boolean -> IProp (disabled :: I | r) i
 ```
 
 #### `required`
 
 ``` purescript
-required :: forall ρ i. Boolean -> IProp (required :: I | ρ) i
+required :: forall r i. Boolean -> IProp (required :: I | r) i
 ```
 
 #### `readonly`
 
 ``` purescript
-readonly :: forall ρ i. Boolean -> IProp (readonly :: I | ρ) i
+readonly :: forall r i. Boolean -> IProp (readonly :: I | r) i
 ```
 
 #### `spellcheck`
 
 ``` purescript
-spellcheck :: forall ρ i. Boolean -> IProp (spellcheck :: I | ρ) i
+spellcheck :: forall r i. Boolean -> IProp (spellcheck :: I | r) i
 ```
 
 #### `enabled`
 
 ``` purescript
-enabled :: forall ρ i. Boolean -> IProp (disabled :: I | ρ) i
+enabled :: forall r i. Boolean -> IProp (disabled :: I | r) i
 ```
 
 #### `checked`
 
 ``` purescript
-checked :: forall ρ i. Boolean -> IProp (checked :: I | ρ) i
+checked :: forall r i. Boolean -> IProp (checked :: I | r) i
 ```
 
 #### `selected`
 
 ``` purescript
-selected :: forall ρ i. Boolean -> IProp (selected :: I | ρ) i
+selected :: forall r i. Boolean -> IProp (selected :: I | r) i
 ```
 
 #### `placeholder`
 
 ``` purescript
-placeholder :: forall ρ i. String -> IProp (placeholder :: I | ρ) i
+placeholder :: forall r i. String -> IProp (placeholder :: I | r) i
 ```
 
 #### `GlobalAttributes`
 
 ``` purescript
-type GlobalAttributes ρ = (id :: I, name :: I, title :: I, class :: I, spellcheck :: I | ρ)
+type GlobalAttributes r = (id :: I, name :: I, title :: I, class :: I, spellcheck :: I, key :: I | r)
 ```
 
 #### `GlobalEvents`
 
 ``` purescript
-type GlobalEvents ρ = (onContextMenu :: I | ρ)
+type GlobalEvents r = (onContextMenu :: I | r)
 ```
 
 #### `MouseEvents`
 
 ``` purescript
-type MouseEvents ρ = (onDoubleClick :: I, onClick :: I, onMouseDown :: I, onMouseEnter :: I, onMouseLeave :: I, onMouseMove :: I, onMouseOver :: I, onMouseOut :: I, onMouseUp :: I | ρ)
+type MouseEvents r = (onDoubleClick :: I, onClick :: I, onMouseDown :: I, onMouseEnter :: I, onMouseLeave :: I, onMouseMove :: I, onMouseOver :: I, onMouseOut :: I, onMouseUp :: I | r)
 ```
 
 #### `KeyEvents`
 
 ``` purescript
-type KeyEvents ρ = (onKeyDown :: I, onKeyUp :: I, onKeyPress :: I | ρ)
+type KeyEvents r = (onKeyDown :: I, onKeyUp :: I, onKeyPress :: I | r)
 ```
 
 #### `FocusEvents`
 
 ``` purescript
-type FocusEvents ρ = (onBlur :: I, onFocus :: I, onFocusIn :: I, onFocusOut :: I | ρ)
+type FocusEvents r = (onBlur :: I, onFocus :: I, onFocusIn :: I, onFocusOut :: I | r)
 ```
 
 #### `InteractiveEvents`
 
 ``` purescript
-type InteractiveEvents ρ = FocusEvents (KeyEvents (MouseEvents ρ))
+type InteractiveEvents r = FocusEvents (KeyEvents (MouseEvents r))
 ```
 
 #### `GlobalProperties`
 
 ``` purescript
-type GlobalProperties ρ = GlobalAttributes (GlobalEvents ρ)
+type GlobalProperties r = GlobalAttributes (GlobalEvents r)
 ```
 
 

--- a/docs/Halogen/HTML/Properties/Indexed/Unsafe.md
+++ b/docs/Halogen/HTML/Properties/Indexed/Unsafe.md
@@ -3,11 +3,11 @@
 #### `IProp`
 
 ``` purescript
-newtype IProp (ρ :: # *) i
+newtype IProp (r :: # *) i
   = IProp (Prop i)
 ```
 
-The phantom row `ρ` can be thought of as a context which is synthesized in the
+The phantom row `r` can be thought of as a context which is synthesized in the
 course of constructing a refined HTML expression.
 
 

--- a/docs/Halogen/Query.md
+++ b/docs/Halogen/Query.md
@@ -1,13 +1,35 @@
 ## Module Halogen.Query
 
+#### `Action`
+
+``` purescript
+type Action f = Unit -> f Unit
+```
+
+Type synonym for an "action" - An action only causes effects and has no
+result value.
+
+In a query algebra, an action is any constructor that carries the algebra's
+type variable as a value. For example:
+
+``` purescript
+data Input a
+  = SomeAction a
+  | SomeOtherAction String a
+  | NotAnAction (Boolean -> a)
+```
+
+Both `SomeAction` and `SomeOtherAction` have `a` as a value so they are
+considered actions, whereas `NotAnAction` has `a` as the result of a
+function so is considered to be a "request" (see below).
+
 #### `action`
 
 ``` purescript
-action :: forall f. (Unit -> f Unit) -> f Unit
+action :: forall f. Action f -> f Unit
 ```
 
-Takes a data constructor of query algebra `f` and creates an "action". An
-"action" only causes effects and has no result value.
+Takes a data constructor of query algebra `f` and creates an action.
 
 For example:
 
@@ -18,15 +40,29 @@ sendTick :: forall eff. Driver Input eff -> Aff (HalogenEffects eff) Unit
 sendTick driver = driver (action Tick)
 ```
 
+#### `Request`
+
+``` purescript
+type Request f a = forall i. (a -> i) -> f i
+```
+
+Type synonym for an "request" - a request can cause effects as well as
+fetching some information from a component.
+
+In a query algebra, an action is any constructor that carries the algebra's
+type variable as the return value of a function. For example:
+
+``` purescript
+data Input a = SomeRequest (Boolean -> a)
+```
+
 #### `request`
 
 ``` purescript
-request :: forall f a. (forall i. (a -> i) -> f i) -> f a
+request :: forall f a. Request f a -> f a
 ```
 
-Takes a data constructor of query algebra `f` and creates a "request". A
-"request" can cause effects as well as fetching some information from a
-component.
+Takes a data constructor of query algebra `f` and creates a request.
 
 For example:
 

--- a/examples/ace/src/Main.purs
+++ b/examples/ace/src/Main.purs
@@ -57,7 +57,7 @@ container = component' render eval peek
   -- | Peek allows us to observe inputs going to the child components, here
   -- | we're using it to observe when the text is changed inside the ace
   -- | component, and igoring any other inputs.
-  peek :: Peek State AceState Input AceInput (Aff (AceEffects eff)) AceSlot p
+  peek :: Peek (ChildF AceSlot AceInput) State AceState Input AceInput (Aff (AceEffects eff)) AceSlot p
   peek (ChildF _ q) = case q of
     ChangeText text _ -> modify _ { text = text }
     _ -> pure unit

--- a/examples/todo/src/Component/List.purs
+++ b/examples/todo/src/Component/List.purs
@@ -45,7 +45,7 @@ list = component' render eval peek
     modify addTask
     pure next
 
-  peek :: Peek State Task ListInput TaskInput g ListSlot p
+  peek :: Peek (ChildF ListSlot TaskInput) State Task ListInput TaskInput g ListSlot p
   peek (ChildF p q) = case q of
     Remove _ -> do
       wasComplete <- query p (request IsCompleted)

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "example-components": "bower link && cd examples/components && bower link purescript-halogen && gulp",
     "example-counter": "bower link && cd examples/counter && bower link purescript-halogen && gulp",
     "example-intro": "bower link && cd examples/intro && bower link purescript-halogen && gulp",
-    "example-todo": "bower link && cd examples/todo && bower link purescript-halogen && gulp",
-    "example-multi-component": "bower link && cd examples/multi-component && bower link purescript-halogen && gulp"
+    "example-interpret": "bower link && cd examples/interpret && bower link purescript-halogen && gulp",
+    "example-multi-component": "bower link && cd examples/multi-component && bower link purescript-halogen && gulp",
+    "example-todo": "bower link && cd examples/todo && bower link purescript-halogen && gulp"
   },
   "devDependencies": {
     "bower": "^1.4.1",

--- a/src/Data/Injector.purs
+++ b/src/Data/Injector.purs
@@ -3,13 +3,14 @@ module Data.Injector
   , Injector()
   , inj
   , prj
+  , injI
   , injLE
   , injLC
   , injRE
   , injRC
   ) where
 
-import Prelude (Applicative, (<<<), const, pure, map)
+import Prelude (Applicative, (<<<), id, const, pure, map)
 
 import Data.Const (Const(..), getConst)
 import Data.Either (Either(..), either)
@@ -50,6 +51,9 @@ prism f g = dimap g (either pure (map f)) <<< PF.right
 
 prism' :: forall s a b. (b -> s) -> (s -> Maybe a) -> Prism s s a b
 prism' f g = prism f (\s -> maybe (Left s) Right (g s))
+
+injI :: forall a. Injector a a
+injI = prism' id Just
 
 injLE :: forall a b. Injector a (Either a b)
 injLE = prism' Left (either Just (const Nothing))

--- a/src/Halogen/Component/ChildPath.purs
+++ b/src/Halogen/Component/ChildPath.purs
@@ -4,7 +4,7 @@ import Prelude ((<<<))
 
 import Data.Either (Either())
 import Data.Functor.Coproduct (Coproduct())
-import Data.Injector (Injector(), prj, inj, injLE, injLC, injRE, injRC)
+import Data.Injector (Injector(), prj, inj, injI, injLE, injLC, injRE, injRC)
 import Data.Maybe (Maybe())
 import Data.NaturalTransformation (Natural())
 
@@ -30,6 +30,10 @@ cpL = ChildPath injLE injLC injLE
 -- | component's `Either` and `Coproduct`s choices.
 cpR :: forall s t f g p q. ChildPath s (Either t s) f (Coproduct g f) p (Either q p)
 cpR = ChildPath injRE injRC injRE
+
+-- | An identity `ChildPath`.
+cpI :: forall s f p. ChildPath s s f f p p
+cpI = ChildPath injI injI injI
 
 -- | Uses a `ChildPath` definition to get a state value of type `s'` from a
 -- | value of type `s`. Used internally by Halogen.

--- a/src/Halogen/Driver.purs
+++ b/src/Halogen/Driver.purs
@@ -21,7 +21,7 @@ import Data.Void (Void())
 
 import DOM.HTML.Types (HTMLElement())
 
-import Halogen.Component (ComponentP(), renderComponent, queryComponent)
+import Halogen.Component (Component(), renderComponent, queryComponent)
 import Halogen.Effects (HalogenEffects())
 import Halogen.HTML.Renderer.VirtualDOM (RenderState(), emptyRenderState, renderHTML)
 import Halogen.Internal.VirtualDOM (VTree(), createElement, diff, patch)
@@ -48,7 +48,7 @@ type DriverState s =
 -- | can be used to send actions and requests into the component (see the
 -- | [`action`](#action), [`request`](#request), and related variations for
 -- | more details on querying the driver).
-runUI :: forall s f eff o. ComponentP s f (Aff (HalogenEffects eff)) o Void
+runUI :: forall s f eff. Component s f (Aff (HalogenEffects eff)) Void
       -> s
       -> Aff (HalogenEffects eff) { node :: HTMLElement, driver :: Driver f eff }
 runUI c s = case renderComponent c s of

--- a/src/Halogen/HTML/Events.purs
+++ b/src/Halogen/HTML/Events.purs
@@ -10,17 +10,17 @@ import Prelude
 
 import Control.Monad.Free (Free())
 
-import Halogen.Query (action)
+import Halogen.Query (Action(), action)
 import Halogen.HTML.Events.Handler (EventHandler(), preventDefault, stopPropagation, stopImmediatePropagation)
 import Halogen.HTML.Events.Types (Event(), MouseEvent(), FocusEvent(), KeyboardEvent())
 import Halogen.HTML.Core (Prop(), handler, eventName)
 
 type EventProp e i = (Event e -> EventHandler i) -> Prop i
 
-input :: forall f a. (forall i. a -> i -> f i) -> a -> EventHandler (f Unit)
+input :: forall f a. (a -> Action f) -> a -> EventHandler (f Unit)
 input f x = pure $ action (f x)
 
-input_ :: forall f a. (forall i. i -> f i) -> a -> EventHandler (f Unit)
+input_ :: forall f a. Action f -> a -> EventHandler (f Unit)
 input_ f _ = pure $ action f
 
 onAbort :: forall i. EventProp () i

--- a/src/Halogen/HTML/Events/Indexed.purs
+++ b/src/Halogen/HTML/Events/Indexed.purs
@@ -49,115 +49,115 @@ import Halogen.HTML.Core (Prop())
 import Halogen.HTML.Properties.Indexed
 import qualified Halogen.HTML.Properties.Indexed.Unsafe as Unsafe
 
-type IEventProp ρ e i = (Event e -> EventHandler i) -> IProp ρ i
+type IEventProp r e i = (Event e -> EventHandler i) -> IProp r i
 
-refine :: forall ρ i. Prop i -> IProp ρ i
+refine :: forall r i. Prop i -> IProp r i
 refine = Unsafe.IProp
 
-onAbort :: forall ρ i. IEventProp (onAbort :: I | ρ) () i
+onAbort :: forall r i. IEventProp (onAbort :: I | r) () i
 onAbort = refine <<< E.onAbort
 
-onBeforeUnload :: forall ρ i. IEventProp (onBeforeUnload :: I | ρ) () i
+onBeforeUnload :: forall r i. IEventProp (onBeforeUnload :: I | r) () i
 onBeforeUnload = refine <<< E.onBeforeUnload
 
-onError :: forall ρ i. IEventProp (onError :: I | ρ) () i
+onError :: forall r i. IEventProp (onError :: I | r) () i
 onError = refine <<< E.onError
 
-onHashChange :: forall ρ i. IEventProp (onHashChange :: I | ρ) () i
+onHashChange :: forall r i. IEventProp (onHashChange :: I | r) () i
 onHashChange = refine <<< E.onHashChange
 
-onLoad :: forall ρ i. IEventProp (onLoad :: I | ρ) () i
+onLoad :: forall r i. IEventProp (onLoad :: I | r) () i
 onLoad = refine <<< E.onLoad
 
-onPageShow :: forall ρ i. IEventProp (onPageShow :: I | ρ) () i
+onPageShow :: forall r i. IEventProp (onPageShow :: I | r) () i
 onPageShow = refine <<< E.onPageShow
 
-onPageHide :: forall ρ i. IEventProp (onPageHide :: I | ρ) () i
+onPageHide :: forall r i. IEventProp (onPageHide :: I | r) () i
 onPageHide = refine <<< E.onPageHide
 
-onResize :: forall ρ i. IEventProp (onResize :: I | ρ) () i
+onResize :: forall r i. IEventProp (onResize :: I | r) () i
 onResize = refine <<< E.onResize
 
-onScroll :: forall ρ i. IEventProp (onScroll :: I | ρ) () i
+onScroll :: forall r i. IEventProp (onScroll :: I | r) () i
 onScroll = refine <<< E.onScroll
 
-onUnload :: forall ρ i. IEventProp (onUnload :: I | ρ) () i
+onUnload :: forall r i. IEventProp (onUnload :: I | r) () i
 onUnload = refine <<< E.onUnload
 
-onChange :: forall ρ i. IEventProp (onChange :: I | ρ) () i
+onChange :: forall r i. IEventProp (onChange :: I | r) () i
 onChange = refine <<< E.onChange
 
-onInput :: forall ρ i. IEventProp (onInput :: I | ρ) () i
+onInput :: forall r i. IEventProp (onInput :: I | r) () i
 onInput = refine <<< E.onInput
 
-onInvalid :: forall ρ i. IEventProp (onInvalid :: I | ρ) () i
+onInvalid :: forall r i. IEventProp (onInvalid :: I | r) () i
 onInvalid = refine <<< E.onInvalid
 
-onReset :: forall ρ i. IEventProp (onReset :: I | ρ) () i
+onReset :: forall r i. IEventProp (onReset :: I | r) () i
 onReset = refine <<< E.onReset
 
-onSearch :: forall ρ i. IEventProp (onSearch :: I | ρ) () i
+onSearch :: forall r i. IEventProp (onSearch :: I | r) () i
 onSearch = refine <<< E.onSearch
 
-onSelect :: forall ρ i. IEventProp (onSelect :: I | ρ) () i
+onSelect :: forall r i. IEventProp (onSelect :: I | r) () i
 onSelect = refine <<< E.onSelect
 
-onSubmit :: forall ρ i. IEventProp (onSubmit :: I | ρ) () i
+onSubmit :: forall r i. IEventProp (onSubmit :: I | r) () i
 onSubmit = refine <<< E.onSubmit
 
-onClick :: forall ρ i. IEventProp (onClick :: I | ρ) MouseEvent i
+onClick :: forall r i. IEventProp (onClick :: I | r) MouseEvent i
 onClick = refine <<< E.onClick
 
-onContextMenu :: forall ρ i. IEventProp (onContextMenu :: I | ρ) MouseEvent i
+onContextMenu :: forall r i. IEventProp (onContextMenu :: I | r) MouseEvent i
 onContextMenu = refine <<< E.onContextMenu
 
-onDoubleClick :: forall ρ i. IEventProp (onDoubleClick :: I | ρ) MouseEvent i
+onDoubleClick :: forall r i. IEventProp (onDoubleClick :: I | r) MouseEvent i
 onDoubleClick = refine <<< E.onDoubleClick
 
-onMouseDown :: forall ρ i. IEventProp (onMouseDown :: I | ρ) MouseEvent i
+onMouseDown :: forall r i. IEventProp (onMouseDown :: I | r) MouseEvent i
 onMouseDown = refine <<< E.onMouseDown
 
-onMouseLeave :: forall ρ i. IEventProp (onMouseLeave :: I | ρ) MouseEvent i
+onMouseLeave :: forall r i. IEventProp (onMouseLeave :: I | r) MouseEvent i
 onMouseLeave = refine <<< E.onMouseLeave
 
-onMouseMove :: forall ρ i. IEventProp (onMouseMove :: I | ρ) MouseEvent i
+onMouseMove :: forall r i. IEventProp (onMouseMove :: I | r) MouseEvent i
 onMouseMove = refine <<< E.onMouseMove
 
-onMouseOver :: forall ρ i. IEventProp (onMouseOver :: I | ρ) MouseEvent i
+onMouseOver :: forall r i. IEventProp (onMouseOver :: I | r) MouseEvent i
 onMouseOver = refine <<< E.onMouseOver
 
-onMouseOut :: forall ρ i. IEventProp (onMouseOut :: I | ρ) MouseEvent i
+onMouseOut :: forall r i. IEventProp (onMouseOut :: I | r) MouseEvent i
 onMouseOut = refine <<< E.onMouseOut
 
-onMouseUp :: forall ρ i. IEventProp (onMouseUp :: I | ρ) MouseEvent i
+onMouseUp :: forall r i. IEventProp (onMouseUp :: I | r) MouseEvent i
 onMouseUp = refine <<< E.onMouseUp
 
-onKeyDown :: forall ρ i. IEventProp (onKeyDown :: I | ρ) KeyboardEvent i
+onKeyDown :: forall r i. IEventProp (onKeyDown :: I | r) KeyboardEvent i
 onKeyDown = refine <<< E.onKeyDown
 
-onKeyPress :: forall ρ i. IEventProp (onKeyPress :: I | ρ) KeyboardEvent i
+onKeyPress :: forall r i. IEventProp (onKeyPress :: I | r) KeyboardEvent i
 onKeyPress = refine <<< E.onKeyPress
 
-onKeyUp :: forall ρ i. IEventProp (onKeyUp :: I | ρ) KeyboardEvent i
+onKeyUp :: forall r i. IEventProp (onKeyUp :: I | r) KeyboardEvent i
 onKeyUp = refine <<< E.onKeyUp
 
-onBlur :: forall ρ i. IEventProp (onBlur :: I | ρ) FocusEvent i
+onBlur :: forall r i. IEventProp (onBlur :: I | r) FocusEvent i
 onBlur = refine <<< E.onBlur
 
-onFocus :: forall ρ i. IEventProp (onFocus :: I | ρ) FocusEvent i
+onFocus :: forall r i. IEventProp (onFocus :: I | r) FocusEvent i
 onFocus = refine <<< E.onFocus
 
-onFocusIn :: forall ρ i. IEventProp (onFocusIn :: I | ρ) FocusEvent i
+onFocusIn :: forall r i. IEventProp (onFocusIn :: I | r) FocusEvent i
 onFocusIn = refine <<< E.onFocusIn
 
-onFocusOut :: forall ρ i. IEventProp (onFocusOut :: I | ρ) FocusEvent i
+onFocusOut :: forall r i. IEventProp (onFocusOut :: I | r) FocusEvent i
 onFocusOut = refine <<< E.onFocusOut
 
-onValueChange :: forall ρ f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onChange :: I | ρ) (f Unit)
+onValueChange :: forall r f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onChange :: I | r) (f Unit)
 onValueChange = refine <<< E.onValueChange
 
-onValueInput :: forall ρ f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onInput :: I | ρ) (f Unit)
+onValueInput :: forall r f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onInput :: I | r) (f Unit)
 onValueInput = refine <<< E.onValueInput
 
-onChecked :: forall ρ f. (Boolean -> EventHandler (f Unit)) -> IProp (checked :: I, onChange :: I | ρ) (f Unit)
+onChecked :: forall r f. (Boolean -> EventHandler (f Unit)) -> IProp (checked :: I, onChange :: I | r) (f Unit)
 onChecked = refine <<< E.onChecked

--- a/src/Halogen/HTML/Properties/Indexed.purs
+++ b/src/Halogen/HTML/Properties/Indexed.purs
@@ -71,69 +71,69 @@ import qualified Halogen.HTML.Properties (LengthLiteral(..)) as PExport
 import qualified Halogen.HTML.Properties.Indexed.Unsafe as Unsafe
 import Halogen.HTML.Core (Prop(..), ClassName(), prop, propName, attrName, runClassName)
 
--- | The phantom row `ρ` can be thought of as a context which is synthesized in the
+-- | The phantom row `r` can be thought of as a context which is synthesized in the
 -- | course of constructing a refined HTML expression.
-type IProp (ρ :: # *) i = Unsafe.IProp ρ i
+type IProp (r :: # *) i = Unsafe.IProp r i
 
 -- | The refined property can be erased into a normal one.
-erase :: forall ρ i. IProp ρ i -> Prop i
+erase :: forall r i. IProp r i -> Prop i
 erase (Unsafe.IProp p) = p
 
-refine :: forall ρ i. Prop i -> IProp ρ i
+refine :: forall r i. Prop i -> IProp r i
 refine = Unsafe.IProp
 
 -- | A dummy type to use in the phantom row.
 data I
 
-key :: forall ρ i. String -> IProp (key :: I | ρ) i
+key :: forall r i. String -> IProp (key :: I | r) i
 key = refine <<< P.key
 
-alt :: forall ρ i. String -> IProp (alt :: I | ρ) i
+alt :: forall r i. String -> IProp (alt :: I | r) i
 alt = refine <<< P.alt
 
-charset :: forall ρ i. String -> IProp (charset :: I | ρ) i
+charset :: forall r i. String -> IProp (charset :: I | r) i
 charset = refine <<< P.charset
 
-class_ :: forall ρ i. ClassName -> IProp (class :: I | ρ) i
+class_ :: forall r i. ClassName -> IProp (class :: I | r) i
 class_ = refine <<< P.class_
 
-classes :: forall ρ i. Array ClassName -> IProp (class :: I | ρ) i
+classes :: forall r i. Array ClassName -> IProp (class :: I | r) i
 classes = refine <<< P.classes
 
-colSpan :: forall ρ i. Int -> IProp (colSpan :: I | ρ) i
+colSpan :: forall r i. Int -> IProp (colSpan :: I | r) i
 colSpan = refine <<< P.colSpan
 
-rowSpan :: forall ρ i. Int -> IProp (rowSpan :: I | ρ) i
+rowSpan :: forall r i. Int -> IProp (rowSpan :: I | r) i
 rowSpan = refine <<< P.rowSpan
 
-for :: forall ρ i. String -> IProp (for :: I | ρ) i
+for :: forall r i. String -> IProp (for :: I | r) i
 for = refine <<< P.for
 
-height :: forall ρ i. P.LengthLiteral -> IProp (height :: I | ρ) i
+height :: forall r i. P.LengthLiteral -> IProp (height :: I | r) i
 height = refine <<< P.height
 
-width :: forall ρ i. P.LengthLiteral -> IProp (width :: I | ρ) i
+width :: forall r i. P.LengthLiteral -> IProp (width :: I | r) i
 width = refine <<< P.width
 
-href :: forall ρ i. String -> IProp (href :: I | ρ) i
+href :: forall r i. String -> IProp (href :: I | r) i
 href = refine <<< P.href
 
-id_ :: forall ρ i. String -> IProp (id :: I | ρ) i
+id_ :: forall r i. String -> IProp (id :: I | r) i
 id_ = refine <<< P.id_
 
-name :: forall ρ i. String -> IProp (name :: I | ρ) i
+name :: forall r i. String -> IProp (name :: I | r) i
 name = refine <<< P.name
 
-rel :: forall ρ i. String -> IProp (rel :: I | ρ) i
+rel :: forall r i. String -> IProp (rel :: I | r) i
 rel = refine <<< P.rel
 
-src :: forall ρ i. String -> IProp (src :: I | ρ) i
+src :: forall r i. String -> IProp (src :: I | r) i
 src = refine <<< P.src
 
-target :: forall ρ i. String -> IProp (target :: I | ρ) i
+target :: forall r i. String -> IProp (target :: I | r) i
 target = refine <<< P.target
 
-title :: forall ρ i. String -> IProp (title :: I | ρ) i
+title :: forall r i. String -> IProp (title :: I | r) i
 title = refine <<< P.title
 
 data InputType
@@ -188,7 +188,7 @@ renderInputType ty =
     InputUrl -> "url"
     InputWeek -> "week"
 
-inputType :: forall ρ i. InputType -> IProp (inputType :: I | ρ) i
+inputType :: forall r i. InputType -> IProp (inputType :: I | r) i
 inputType = refine <<< P.type_ <<< renderInputType
 
 data MenuType
@@ -203,7 +203,7 @@ renderMenuType ty =
     MenuContext -> "context"
     MenuToolbar -> "toolbar"
 
-menuType :: forall ρ i. MenuType -> IProp (menuType :: I | ρ) i
+menuType :: forall r i. MenuType -> IProp (menuType :: I | r) i
 menuType = refine <<< P.type_ <<< renderMenuType
 
 data MenuitemType
@@ -218,7 +218,7 @@ renderMenuitemType ty =
     MenuitemCheckbox -> "checkbox"
     MenuitemRadio -> "radio"
 
-menuitemType :: forall ρ i. MenuitemType -> IProp (menuitemType :: I | ρ) i
+menuitemType :: forall r i. MenuitemType -> IProp (menuitemType :: I | r) i
 menuitemType= refine <<< P.type_ <<< renderMenuitemType
 
 type MediaType =
@@ -238,7 +238,7 @@ renderMediaType ty = ty.type ++ "/" ++ ty.subtype ++ renderParameters ty.paramet
     renderParameter :: Tuple String String -> String
     renderParameter (Tuple k v) = k ++ "=" ++ v
 
-mediaType :: forall ρ i. MediaType -> IProp (mediaType :: I | ρ) i
+mediaType :: forall r i. MediaType -> IProp (mediaType :: I | r) i
 mediaType = refine <<< P.type_ <<< renderMediaType
 
 data ButtonType
@@ -253,7 +253,7 @@ renderButtonType ty =
     ButtonSubmit -> "submit"
     ButtonReset -> "reset"
 
-buttonType :: forall ρ i. ButtonType -> IProp (buttonType :: I | ρ) i
+buttonType :: forall r i. ButtonType -> IProp (buttonType :: I | r) i
 buttonType = refine <<< P.type_ <<< renderButtonType
 
 data CaseType
@@ -283,52 +283,52 @@ renderOrderedListType ty =
         Lowercase -> "a"
         Uppercase -> "A"
 
-olType :: forall ρ i. OrderedListType -> IProp (olType :: I | ρ) i
+olType :: forall r i. OrderedListType -> IProp (olType :: I | r) i
 olType = refine <<< P.type_ <<< renderOrderedListType
 
-value :: forall ρ i. String -> IProp (value :: I | ρ) i
+value :: forall r i. String -> IProp (value :: I | r) i
 value = refine <<< P.value
 
-disabled :: forall ρ i. Boolean -> IProp (disabled :: I | ρ) i
+disabled :: forall r i. Boolean -> IProp (disabled :: I | r) i
 disabled = refine <<< P.disabled
 
-required :: forall ρ i. Boolean -> IProp (required :: I | ρ) i
+required :: forall r i. Boolean -> IProp (required :: I | r) i
 required = refine <<< P.required
 
-readonly :: forall ρ i. Boolean -> IProp (readonly :: I | ρ) i
+readonly :: forall r i. Boolean -> IProp (readonly :: I | r) i
 readonly = refine <<< P.readonly
 
-spellcheck :: forall ρ i. Boolean -> IProp (spellcheck :: I | ρ) i
+spellcheck :: forall r i. Boolean -> IProp (spellcheck :: I | r) i
 spellcheck = refine <<< P.spellcheck
 
-enabled :: forall ρ i. Boolean -> IProp (disabled :: I | ρ) i
+enabled :: forall r i. Boolean -> IProp (disabled :: I | r) i
 enabled = disabled <<< not
 
-checked :: forall ρ i. Boolean -> IProp (checked :: I | ρ) i
+checked :: forall r i. Boolean -> IProp (checked :: I | r) i
 checked = refine <<< P.checked
 
-selected :: forall ρ i. Boolean -> IProp (selected :: I | ρ) i
+selected :: forall r i. Boolean -> IProp (selected :: I | r) i
 selected = refine <<< P.selected
 
-placeholder :: forall ρ i. String -> IProp (placeholder :: I | ρ) i
+placeholder :: forall r i. String -> IProp (placeholder :: I | r) i
 placeholder = refine <<< P.placeholder
 
-type GlobalAttributes ρ =
+type GlobalAttributes r =
   ( id :: I
   , name :: I
   , title :: I
   , class :: I
   , spellcheck :: I
   , key :: I
-  | ρ
+  | r
   )
 
-type GlobalEvents ρ =
+type GlobalEvents r =
   ( onContextMenu :: I
-  | ρ
+  | r
   )
 
-type MouseEvents ρ =
+type MouseEvents r =
   ( onDoubleClick :: I
   , onClick :: I
   , onMouseDown :: I
@@ -338,23 +338,23 @@ type MouseEvents ρ =
   , onMouseOver :: I
   , onMouseOut :: I
   , onMouseUp :: I
-  | ρ
+  | r
   )
 
-type KeyEvents ρ =
+type KeyEvents r =
   ( onKeyDown :: I
   , onKeyUp :: I
   , onKeyPress :: I
-  | ρ
+  | r
   )
 
-type FocusEvents ρ =
+type FocusEvents r =
   ( onBlur :: I
   , onFocus :: I
   , onFocusIn :: I
   , onFocusOut :: I
-  | ρ
+  | r
   )
 
-type InteractiveEvents ρ = FocusEvents (KeyEvents (MouseEvents ρ))
-type GlobalProperties ρ = GlobalAttributes (GlobalEvents ρ)
+type InteractiveEvents r = FocusEvents (KeyEvents (MouseEvents r))
+type GlobalProperties r = GlobalAttributes (GlobalEvents r)

--- a/src/Halogen/HTML/Properties/Indexed/Unsafe.purs
+++ b/src/Halogen/HTML/Properties/Indexed/Unsafe.purs
@@ -4,6 +4,6 @@ module Halogen.HTML.Properties.Indexed.Unsafe
 
 import Halogen.HTML.Core (Prop())
 
--- | The phantom row `ρ` can be thought of as a context which is synthesized in the
+-- | The phantom row `r` can be thought of as a context which is synthesized in the
 -- | course of constructing a refined HTML expression.
-newtype IProp (ρ :: # *) i = IProp (Prop i)
+newtype IProp (r :: # *) i = IProp (Prop i)


### PR DESCRIPTION
- The change to `runUI` to only accept `Component` is okay because `ComponentP` is only used by components-with-children that have not yet had their children installed.
- Renaming `ρ` to `r` for the phantom rows is unfortunate, but seems like the best option currently to ensure "everyone" can build Halogen
- Forgot to add the `interpret` example to the stuff travis runs when I did that PR