### PR TITLE
Make `key` a global attribute

### DIFF
--- a/src/Halogen/HTML/Properties/Indexed.purs
+++ b/src/Halogen/HTML/Properties/Indexed.purs
@@ -319,6 +319,7 @@ type GlobalAttributes ρ =
   , title :: I
   , class :: I
   , spellcheck :: I
+  , key :: I
   | ρ
   )
 


### PR DESCRIPTION
It's entirely possible that I'm misinterpreting something here, but it seems to me that it should be possible to set a `key` for every attribute. Is that assumption correct?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/slamdata/purescript-halogen/182)
<!-- Reviewable:end -->
