### PR TITLE
Fix rowspan/colspan prop indices / refinements

### DIFF
--- a/docs/Halogen/HTML/Elements/Indexed.md
+++ b/docs/Halogen/HTML/Elements/Indexed.md
@@ -653,7 +653,7 @@ tbody :: forall p i. Node (onScroll :: I) p i
 #### `td`
 
 ``` purescript
-td :: forall p i. Node (colspan :: I, headers :: I, rowspan :: I) p i
+td :: forall p i. Node (colSpan :: I, headers :: I, rowSpan :: I) p i
 ```
 
 #### `textarea`
@@ -671,7 +671,7 @@ tfoot :: forall p i. Node (onScroll :: I) p i
 #### `th`
 
 ``` purescript
-th :: forall p i. Node (abbr :: I, colspan :: I, headers :: I, rowspan :: I, scope :: I, sorted :: I) p i
+th :: forall p i. Node (abbr :: I, colSpan :: I, headers :: I, rowSpan :: I, scope :: I, sorted :: I) p i
 ```
 
 #### `thead`

--- a/src/Halogen/HTML/Elements/Indexed.purs
+++ b/src/Halogen/HTML/Elements/Indexed.purs
@@ -572,7 +572,7 @@ table = unsafeCoerce E.table
 tbody :: forall p i. Node (onScroll :: I) p i
 tbody = unsafeCoerce E.tbody
 
-td :: forall p i. Node (colspan :: I, headers :: I, rowspan :: I) p i
+td :: forall p i. Node (colSpan :: I, headers :: I, rowSpan :: I) p i
 td = unsafeCoerce E.td
 
 textarea :: forall p i. Leaf (autofocus :: I, cols :: I, disabled :: I, form :: I, maxlength :: I, onChange :: I, onInput :: I, onScroll :: I, onSelect :: I, placeholder :: I, readonly :: I, required :: I, rows :: I, value :: I, wrap :: I) p i
@@ -581,7 +581,7 @@ textarea = unsafeCoerce E.textarea
 tfoot :: forall p i. Node (onScroll :: I) p i
 tfoot = unsafeCoerce E.tfoot
 
-th :: forall p i. Node (abbr :: I, colspan :: I, headers :: I, rowspan :: I, scope :: I, sorted :: I) p i
+th :: forall p i. Node (abbr :: I, colSpan :: I, headers :: I, rowSpan :: I, scope :: I, sorted :: I) p i
 th = unsafeCoerce E.th
 
 thead :: forall p i. Node () p i


### PR DESCRIPTION
There was a difference of case between the `Elements.Indexed` and `Properties.Indexed` modules.