### PR TITLE
Remove unnecessary `p`

### DIFF
--- a/docs/Halogen/Driver.md
+++ b/docs/Halogen/Driver.md
@@ -13,7 +13,7 @@ query has been fulfilled.
 #### `runUI`
 
 ``` purescript
-runUI :: forall s f eff. Component s f (Aff (HalogenEffects eff)) Void -> s -> Aff (HalogenEffects eff) { node :: HTMLElement, driver :: Driver f eff }
+runUI :: forall s f eff. Component s f (Aff (HalogenEffects eff)) -> s -> Aff (HalogenEffects eff) { node :: HTMLElement, driver :: Driver f eff }
 ```
 
 Runs the top level UI component for a Halogen app, returning a generated

--- a/examples/ace/src/AceComponent.purs
+++ b/examples/ace/src/AceComponent.purs
@@ -30,11 +30,11 @@ initAceState = { editor: Nothing }
 
 type AceEffects eff = (ace :: ACE, avar :: AVAR, console :: CONSOLE | eff)
 
-ace :: forall p eff. String -> Component AceState AceInput (Aff (AceEffects eff)) p
+ace :: forall eff. String -> Component AceState AceInput (Aff (AceEffects eff))
 ace key = component render eval
   where
 
-  render :: Render AceState AceInput p
+  render :: Render AceState AceInput
   render = const $ H.div [ initializer ] []
 
   initializer :: Prop AceInput

--- a/examples/ace/src/Main.purs
+++ b/examples/ace/src/Main.purs
@@ -34,11 +34,11 @@ instance eqAceSlot :: Eq AceSlot where eq = gEq
 instance ordAceSlot :: Ord AceSlot where compare = gCompare
 
 -- | The parent component that the ace component will be installed into.
-container :: forall p eff. ParentComponentP State AceState Input AceInput (Aff (AceEffects eff)) AceSlot p
-container = component' render eval peek
+container :: forall eff. ParentComponentP State AceState Input AceInput (Aff (AceEffects eff)) AceSlot
+container = parentComponent' render eval peek
   where
 
-  render :: Render State Input AceSlot
+  render :: RenderP State Input AceSlot
   render { text: text } =
     H.div_ [ H.h1_ [ H.text "ace editor" ]
            , H.div_ [ H.p_ [ H.button [ E.onClick (E.input_ ClearText) ]
@@ -49,7 +49,7 @@ container = component' render eval peek
            , H.p_ [ H.text ("Current text: " ++ text) ]
            ]
 
-  eval :: EvalP Input State AceState Input AceInput (Aff (AceEffects eff)) AceSlot p
+  eval :: EvalP Input State AceState Input AceInput (Aff (AceEffects eff)) AceSlot
   eval (ClearText next) = do
     query (AceSlot "test-ace") (action $ ChangeText "")
     pure next
@@ -57,13 +57,13 @@ container = component' render eval peek
   -- | Peek allows us to observe inputs going to the child components, here
   -- | we're using it to observe when the text is changed inside the ace
   -- | component, and igoring any other inputs.
-  peek :: Peek (ChildF AceSlot AceInput) State AceState Input AceInput (Aff (AceEffects eff)) AceSlot p
+  peek :: Peek (ChildF AceSlot AceInput) State AceState Input AceInput (Aff (AceEffects eff)) AceSlot
   peek (ChildF _ q) = case q of
     ChangeText text _ -> modify _ { text = text }
     _ -> pure unit
 
 -- | The main UI component - the parent component with installed ace component.
-ui :: forall p eff. InstalledComponent State AceState Input AceInput (Aff (AceEffects eff)) AceSlot p
+ui :: forall eff. InstalledComponent State AceState Input AceInput (Aff (AceEffects eff)) AceSlot
 ui = install' container mkAce
   where
   mkAce (AceSlot name) = createChild (ace name) initAceState

--- a/examples/ajax/src/Ajax.purs
+++ b/examples/ajax/src/Ajax.purs
@@ -50,11 +50,11 @@ data Input a
 type AppEffects eff = HalogenEffects (ajax :: AJAX | eff)
 
 -- | The definition for the app's main UI component.
-ui :: forall eff p. Component State Input (Aff (AppEffects eff)) p
+ui :: forall eff. Component State Input (Aff (AppEffects eff))
 ui = component render eval
   where
 
-  render :: Render State Input p
+  render :: Render State Input
   render st =
     H.div_ $ [ H.h1_ [ H.text "ajax example / trypurescript" ]
              , H.h2_ [ H.text "purescript input:" ]

--- a/examples/components/src/Main.purs
+++ b/examples/components/src/Main.purs
@@ -30,11 +30,11 @@ derive instance genericTickSlot :: Generic TickSlot
 instance eqTickSlot :: Eq TickSlot where eq = gEq
 instance ordTickSlot :: Ord TickSlot where compare = gCompare
 
-uiContainer :: forall g p. (Functor g) => ParentComponent State TickState Input TickInput g TickSlot p
-uiContainer = component render eval
+uiContainer :: forall g. (Functor g) => ParentComponent State TickState Input TickInput g TickSlot
+uiContainer = parentComponent render eval
   where
 
-  render :: Render State Input TickSlot
+  render :: RenderP State Input TickSlot
   render st =
     H.div_ [ H.slot (TickSlot "A")
            , H.slot (TickSlot "B")
@@ -44,14 +44,14 @@ uiContainer = component render eval
                   ]
            ]
 
-  eval :: EvalP Input State TickState Input TickInput g TickSlot p
+  eval :: EvalP Input State TickState Input TickInput g TickSlot
   eval (ReadTicks next) = do
     a <- query (TickSlot "A") (request GetTick)
     b <- query (TickSlot "B") (request GetTick)
     modify (\_ -> { tickA: a, tickB: b })
     pure next
 
-ui :: forall g p. (Plus g) => InstalledComponent State TickState Input TickInput g TickSlot p
+ui :: forall g p. (Plus g) => InstalledComponent State TickState Input TickInput g TickSlot
 ui = install uiContainer mkTicker
   where
   mkTicker (TickSlot "A") = createChild ticker (TickState 100)

--- a/examples/components/src/Ticker.purs
+++ b/examples/components/src/Ticker.purs
@@ -13,11 +13,11 @@ data TickInput a
   = Tick a
   | GetTick (Int -> a)
 
-ticker :: forall g p. (Functor g) => Component TickState TickInput g p
+ticker :: forall g. (Functor g) => Component TickState TickInput g
 ticker = component render eval
   where
 
-  render :: Render TickState TickInput p
+  render :: Render TickState TickInput
   render (TickState n) =
     H.div_ [ H.h1 [ P.id_ "header" ] [ H.text "counter" ]
            , H.p_ [ H.text (show n) ]

--- a/examples/counter/src/Counter.purs
+++ b/examples/counter/src/Counter.purs
@@ -22,11 +22,11 @@ initialState = State 0
 data Input a = Tick a
 
 -- | The main UI component.
-ui :: forall g p. (Functor g) => Component State Input g p
+ui :: forall g. (Functor g) => Component State Input g
 ui = component render eval
   where
 
-  render :: Render State Input p
+  render :: Render State Input
   render (State n) =
     H.div_ [ H.h1 [ P.id_ "header" ] [ H.text "counter" ]
            , H.p_ [ H.text (show n) ]

--- a/examples/interpret/src/Main.purs
+++ b/examples/interpret/src/Main.purs
@@ -31,11 +31,11 @@ type Output = Free OutputF
 output :: String -> Output Unit
 output msg = liftF (Log msg unit)
 
-ui :: forall p. Component State Input Output p
+ui :: Component State Input Output
 ui = component render eval
   where
 
-  render :: Render State Input p
+  render :: Render State Input
   render state = H.div_
     [ H.h1_ [ H.text "Toggle Button" ]
     , H.button [ E.onClick (E.input_ ToggleState) ]
@@ -48,7 +48,7 @@ ui = component render eval
     liftH $ output "State was toggled"
     pure next
 
-ui' :: forall eff p. Component State Input (Aff (HalogenEffects (console :: CONSOLE | eff))) p
+ui' :: forall eff. Component State Input (Aff (HalogenEffects (console :: CONSOLE | eff)))
 ui' = interpret (foldFree evalOutput) ui
   where
   evalOutput :: Natural OutputF (Aff (HalogenEffects (console :: CONSOLE | eff)))

--- a/examples/intro/src/Main.purs
+++ b/examples/intro/src/Main.purs
@@ -20,11 +20,11 @@ initialState = { on: false }
 -- | Inputs to the state machine
 data Input a = ToggleState a
 
-ui :: forall g p. (Functor g) => Component State Input g p
+ui :: forall g. (Functor g) => Component State Input g
 ui = component render eval
   where
 
-  render :: Render State Input p
+  render :: Render State Input
   render state = H.div_
     [ H.h1_ [ H.text "Toggle Button" ]
     , H.button [ E.onClick (E.input_ ToggleState) ]

--- a/examples/multi-component/src/ComponentA.purs
+++ b/examples/multi-component/src/ComponentA.purs
@@ -22,11 +22,11 @@ derive instance genericSlotA :: Generic SlotA
 instance eqSlotA :: Eq SlotA where eq = gEq
 instance ordSlotA :: Ord SlotA where compare = gCompare
 
-componentA :: forall g p. (Functor g) => Component StateA InputA g p
+componentA :: forall g. (Functor g) => Component StateA InputA g
 componentA = component render eval
   where
 
-  render :: Render StateA InputA p
+  render :: Render StateA InputA
   render (StateA state) = H.div_
     [ H.h1_ [ H.text "Toggle Button A" ]
     , H.button [ E.onClick (E.input_ ToggleStateA) ]

--- a/examples/multi-component/src/ComponentB.purs
+++ b/examples/multi-component/src/ComponentB.purs
@@ -22,11 +22,11 @@ derive instance genericSlotB :: Generic SlotB
 instance eqSlotB :: Eq SlotB where eq = gEq
 instance ordSlotB :: Ord SlotB where compare = gCompare
 
-componentB :: forall g p. (Functor g) => Component StateB InputB g p
+componentB :: forall g. (Functor g) => Component StateB InputB g
 componentB = component render eval
   where
 
-  render :: Render StateB InputB p
+  render :: Render StateB InputB
   render (StateB state) = H.div_
     [ H.h1_ [ H.text "Toggle Button B" ]
     , H.button [ E.onClick (E.input_ ToggleStateB) ]

--- a/examples/multi-component/src/ComponentC.purs
+++ b/examples/multi-component/src/ComponentC.purs
@@ -22,11 +22,11 @@ derive instance genericSlotC :: Generic SlotC
 instance eqSlotC :: Eq SlotC where eq = gEq
 instance ordSlotC :: Ord SlotC where compare = gCompare
 
-componentC :: forall g p. (Functor g) => Component StateC InputC g p
+componentC :: forall g. (Functor g) => Component StateC InputC g
 componentC = component render eval
   where
 
-  render :: Render StateC InputC p
+  render :: Render StateC InputC
   render (StateC state) = H.div_
     [ H.h1_ [ H.text "Toggle Button C" ]
     , H.button [ E.onClick (E.input_ ToggleStateC) ]

--- a/examples/multi-component/src/Main.purs
+++ b/examples/multi-component/src/Main.purs
@@ -42,11 +42,11 @@ cpB = cpR :> cpL
 cpC :: ChildPath StateC ChildStates InputC ChildInputs SlotC ChildSlots
 cpC = cpR :> cpR
 
-parent :: forall g p. (Functor g) => ParentComponent State ChildStates Input ChildInputs g ChildSlots p
-parent = component render eval
+parent :: forall g. (Functor g) => ParentComponent State ChildStates Input ChildInputs g ChildSlots
+parent = parentComponent render eval
   where
 
-  render :: Render State Input ChildSlots
+  render :: RenderP State Input ChildSlots
   render (State state) = H.div_
     [ H.div_ [ H.slot' cpA SlotA ]
     , H.div_ [ H.slot' cpB SlotB ]
@@ -55,7 +55,7 @@ parent = component render eval
     , H.button [ E.onClick (E.input_ ReadStates) ] [ H.text "Read states" ]
     ]
 
-  eval :: EvalP Input State ChildStates Input ChildInputs g ChildSlots p
+  eval :: EvalP Input State ChildStates Input ChildInputs g ChildSlots
   eval (ReadStates next) = do
     a <- query' cpA SlotA (request GetStateA)
     b <- query' cpB SlotB (request GetStateB)
@@ -63,7 +63,7 @@ parent = component render eval
     modify (const $ State { a: a, b: b, c: c })
     pure next
 
-ui :: forall g p. (Plus g) => InstalledComponent State ChildStates Input ChildInputs g ChildSlots p
+ui :: forall g. (Plus g) => InstalledComponent State ChildStates Input ChildInputs g ChildSlots
 ui = install parent (either installA (either installB installC))
   where
   installA SlotA = createChild' cpA componentA initStateA

--- a/examples/todo/src/Component/List.purs
+++ b/examples/todo/src/Component/List.purs
@@ -26,11 +26,11 @@ instance eqListSlot :: Eq ListSlot where eq = gEq
 instance ordListSlot :: Ord ListSlot where compare = gCompare
 
 -- | The list component definition.
-list :: forall g p. (Functor g) => ParentComponentP State Task ListInput TaskInput g ListSlot p
-list = component' render eval peek
+list :: forall g. (Functor g) => ParentComponentP State Task ListInput TaskInput g ListSlot
+list = parentComponent' render eval peek
   where
 
-  render :: Render State ListInput ListSlot
+  render :: RenderP State ListInput ListSlot
   render st =
     H.div_ [ H.h1_ [ H.text "Todo list" ]
            , H.p_ [ H.button [ E.onClick (E.input_ NewTask) ]
@@ -40,12 +40,12 @@ list = component' render eval peek
            , H.p_ [ H.text $ show st.numCompleted ++ " / " ++ show (length st.tasks) ++ " complete" ]
            ]
 
-  eval :: EvalP ListInput State Task ListInput TaskInput g ListSlot p
+  eval :: EvalP ListInput State Task ListInput TaskInput g ListSlot
   eval (NewTask next) = do
     modify addTask
     pure next
 
-  peek :: Peek (ChildF ListSlot TaskInput) State Task ListInput TaskInput g ListSlot p
+  peek :: Peek (ChildF ListSlot TaskInput) State Task ListInput TaskInput g ListSlot
   peek (ChildF p q) = case q of
     Remove _ -> do
       wasComplete <- query p (request IsCompleted)

--- a/examples/todo/src/Component/Task.purs
+++ b/examples/todo/src/Component/Task.purs
@@ -17,11 +17,11 @@ data TaskInput a
   | IsCompleted (Boolean -> a)
 
 -- | The task component definition.
-task :: forall g p. (Functor g) => Component Task TaskInput g p
+task :: forall g. (Functor g) => Component Task TaskInput g
 task = component render eval
   where
 
-  render :: Render Task TaskInput p
+  render :: Render Task TaskInput
   render t =
     H.li_ [ H.input [ P.inputType P.InputCheckbox
                     , P.title "Mark as completed"

--- a/examples/todo/src/Main.purs
+++ b/examples/todo/src/Main.purs
@@ -14,7 +14,7 @@ import Model
 import Component.List
 import Component.Task
 
-ui :: forall g p. (Plus g) => InstalledComponent State Task ListInput TaskInput g ListSlot p
+ui :: forall g. (Plus g) => InstalledComponent State Task ListInput TaskInput g ListSlot
 ui = install' list mkTask
   where
   mkTask (ListSlot _) = createChild task { description: "", completed: false }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "gulp": "^3.8.11",
     "gulp-jscs": "^1.6.0",
     "gulp-jshint": "^1.11.2",
-    "gulp-purescript": "^0.6.0",
-    "purescript": "^0.7.4-rc.2",
+    "gulp-purescript": "^0.7.0",
+    "purescript": "^0.7.4",
     "rimraf": "^2.4.1",
     "webpack-stream": "^2.0.0"
   },

--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -2,6 +2,7 @@ module Halogen.Component
   ( ComponentP()
   , Component()
   , Render()
+  , RenderP()
   , Eval()
   , EvalP()
   , Peek()
@@ -9,6 +10,8 @@ module Halogen.Component
   , renderComponent
   , queryComponent
   , component
+  , parentComponent'
+  , parentComponent
   , component'
   , ChildState()
   , createChild
@@ -79,14 +82,16 @@ newtype ComponentP s f g o p = Component
   , peek   :: PeekP o s f g
   }
 
--- | A type alias for Halogen components where `peek` is not used.
-type Component s f g = ComponentP s f g (Const Void)
+-- | A type alias for self-contained Halogen components.
+type Component s f g = ComponentP s f g (Const Void) Void
 
 instance functorComponent :: Functor (ComponentP s f g o) where
   map f (Component c) = Component { render: lmap f <$> c.render, eval: c.eval, peek: c.peek }
 
 -- | A type alias for a component `render` function.
-type Render s f p = s -> HTML p (f Unit)
+type Render s f = RenderP s f Void
+
+type RenderP s f p = s -> HTML p (f Unit)
 
 -- | A type alias for a component `eval` function that takes a value from the
 -- | component's query algebra and returns a `Free` monad of the Halogen
@@ -94,11 +99,11 @@ type Render s f p = s -> HTML p (f Unit)
 type Eval i s f g = Natural i (Free (HalogenF s f g))
 
 -- | A convenience variation on `Eval` for parent components.
-type EvalP i s s' f f' g p p' = Eval i s f (QueryF s s' f f' g p p')
+type EvalP i s s' f f' g p = Eval i s f (QueryF s s' f f' g p)
 
 -- | A type alias for a component `peek` function that observes inputs to child
 -- | components.
-type Peek i s s' f f' g p p' = PeekP i s f (QueryF s s' f f' g p p')
+type Peek i s s' f f' g p = PeekP i s f (QueryF s s' f f' g p)
 
 -- | A lower level form of the `Peek` type synonym, used internally.
 type PeekP i s f g = forall a. i a -> Free (HalogenF s f g) Unit
@@ -117,62 +122,67 @@ queryComponent (Component c) = c.eval
 peekComponent :: forall s f g o p. ComponentP s f g o p -> PeekP o s f g
 peekComponent (Component c) = c.peek
 
--- | Builds a new [`Component`](#component) from a [`Render`](#render) and
--- | [`Eval`](#eval) function.
-component :: forall s f g p. Render s f p -> Eval f s f g -> Component s f g p
-component r q = Component { render: CMS.gets r, eval: q, peek: const (pure unit) }
+-- | A low level constructor for building components.
+component' :: forall s f g o p. RenderP s f p -> Eval f s f g -> PeekP o s f g -> ComponentP s f g o p
+component' r e p = Component { render: CMS.gets r, eval: e, peek: p }
 
--- | Builds a new [`ComponentP`](#componentp) from a [`Render`](#render),
--- | [`Eval`](#eval), and [`Peek`](#peek) function. This is used in cases where
--- | defining a parent component that needs to observe inputs to its children.
-component' :: forall s s' f f' g p p'. Render s f p -> EvalP f s s' f f' g p p' -> Peek (ChildF p f') s s' f f' g p p' -> ParentComponentP s s' f f' g p p'
-component' r q p = Component { render: CMS.gets r, eval: q, peek: p }
+-- | Builds a self-contained component with no children.
+component :: forall s f g. Render s f -> Eval f s f g -> Component s f g
+component r e = component' r e (const (pure unit))
+
+-- | Builds a parent component.
+parentComponent :: forall s s' f f' g p. RenderP s f p -> EvalP f s s' f f' g p -> ParentComponent s s' f f' g p
+parentComponent r e = component' r e (const (pure unit))
+
+-- | Builds a parent component that can peek on its children.
+parentComponent' :: forall s s' f f' g p. RenderP s f p -> EvalP f s s' f f' g p -> Peek (ChildF p f') s s' f f' g p -> ParentComponentP s s' f f' g p
+parentComponent' = component'
 
 -- | A type synonym for a component combined with its state. This is used when
 -- | installing components into slots.
-type ChildState s f g p = Tuple (Component s f g p) s
+type ChildState s f g = Tuple (Component s f g) s
 
 -- | Creates a `ChildState` for a component.
-createChild :: forall s f g p. Component s f g p -> s -> ChildState s f g p
+createChild :: forall s f g. Component s f g -> s -> ChildState s f g
 createChild c s = Tuple c s
 
 -- | Creates a `ChildState` for a component that is being installed into a
 -- | parent with multiple different types of child component.
-createChild' :: forall s s' f f' g p p' q. (Functor g) => ChildPath s s' f f' p p' -> Component s f g q -> s -> ChildState s' f' g q
+createChild' :: forall s s' f f' g p p'. (Functor g) => ChildPath s s' f f' p p' -> Component s f g -> s -> ChildState s' f' g
 createChild' i c s = Tuple (transform i c) (injState i s)
 
 -- | A type alias used to simplify the type signature for a `Component s f g p`
 -- | that is intended to have components of type `Component s' f' g p'`
 -- | installed into it.
-type ParentComponent s s' f f' g p p' = Component s f (QueryF s s' f f' g p p') p
+type ParentComponent s s' f f' g p = ComponentP s f (QueryF s s' f f' g p) (Const Void) p
 
 -- | A type alias similar to `ParentComponent`, but for components that `peek`
 -- | on their children.
-type ParentComponentP s s' f f' g p p' = ComponentP s f (QueryF s s' f f' g p p') (ChildF p f') p
+type ParentComponentP s s' f f' g p = ComponentP s f (QueryF s s' f f' g p) (ChildF p f') p
 
 -- | A type alias use to simplify the type signature for a `Component s f g p`
 -- | that has had components of type `Component s' f' g p'` installed into it.
-type InstalledComponent s s' f f' g p p' = Component (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g p'
+type InstalledComponent s s' f f' g p = Component (InstalledState s s' f f' g p) (Coproduct f (ChildF p f')) g
 
 -- | The type used by component containers for their state where `s` is the
 -- | state local to the container, `p` is the type of slot used by the
 -- | container, and the remaining parameters are the type variables for the
 -- | child components.
-type InstalledState s s' f f' g p p' =
+type InstalledState s s' f f' g p =
   { parent   :: s
-  , children :: M.Map p (ChildState s' f' g p')
-  , memo     :: M.Map p (HTML p' (Coproduct f (ChildF p f') Unit))
+  , children :: M.Map p (ChildState s' f' g)
+  , memo     :: M.Map p (HTML Void (Coproduct f (ChildF p f') Unit))
   }
 
 -- | Creates an initial `InstalledState` value for a component container based
 -- | on a state value for the container.
-installedState :: forall s s' f f' g p p'. (Ord p) => s -> InstalledState s s' f f' g p p'
+installedState :: forall s s' f f' g p. (Ord p) => s -> InstalledState s s' f f' g p
 installedState = { parent: _, children: M.empty, memo: M.empty }
 
 -- | An intermediate algebra that parent components "produce" from their `eval`
 -- | and `peek` functions. This takes the place of `g` when compared to a leaf
 -- | (non-parent) component.
-type QueryF s s' f f' g p p' = Free (HalogenF (InstalledState s s' f f' g p p') (ChildF p f') g)
+type QueryF s s' f f' g p = Free (HalogenF (InstalledState s s' f f' g p) (ChildF p f') g)
 
 -- | An intermediate algebra used to associate values from a child component's
 -- | algebra with the slot the component was installed into.
@@ -183,19 +193,19 @@ instance functorChildF :: (Functor f) => Functor (ChildF p f) where
 
 -- | Queries a child component, for use within a parent component's `eval` or
 -- | `peek` function.
-query :: forall s s' f f' g p p' i. (Functor g, Ord p)
+query :: forall s s' f f' g p i. (Functor g, Ord p)
       => p
       -> f' i
-      -> Free (HalogenF s f (QueryF s s' f f' g p p')) (Maybe i)
+      -> Free (HalogenF s f (QueryF s s' f f' g p)) (Maybe i)
 query p q = liftQuery (mkQuery p q)
 
 -- | A version of [`query`](#query) for use when a parent component has multiple
 -- | types of child component.
-query' :: forall s s' s'' f f' f'' g p p' p'' i. (Functor g, Ord p')
+query' :: forall s s' s'' f f' f'' g p p' i. (Functor g, Ord p')
        => ChildPath s s' f f' p p'
        -> p
        -> f i
-       -> Free (HalogenF s'' f'' (QueryF s'' s' f'' f' g p' p'')) (Maybe i)
+       -> Free (HalogenF s'' f'' (QueryF s'' s' f'' f' g p')) (Maybe i)
 query' i p q = liftQuery (mkQuery' i p q)
 
 -- | Creates a query for a child component where `p` is the slot the component
@@ -203,10 +213,10 @@ query' i p q = liftQuery (mkQuery' i p q)
 -- |
 -- | If a component is not found for the slot the result of the query
 -- | will be `Nothing`.
-mkQuery :: forall s s' f f' p p' g i. (Functor g, Ord p)
+mkQuery :: forall s s' f f' p g i. (Functor g, Ord p)
       => p
       -> f' i
-      -> QueryF s s' f f' g p p' (Maybe i)
+      -> QueryF s s' f f' g p (Maybe i)
 mkQuery p q = do
   st <- get
   case M.lookup p st.children of
@@ -215,125 +225,125 @@ mkQuery p q = do
 
 -- | A version of [`mkQuery`](#mkQuery) for use when a parent component has
 -- | multiple types of child component.
-mkQuery' :: forall s s' s'' f f' f'' g p p' p'' i. (Functor g, Ord p')
+mkQuery' :: forall s s' s'' f f' f'' g p p' i. (Functor g, Ord p')
          => ChildPath s s' f f' p p'
          -> p
          -> f i
-         -> QueryF s'' s' f'' f' g p' p'' (Maybe i)
+         -> QueryF s'' s' f'' f' g p' (Maybe i)
 mkQuery' i p q = mkQuery (injSlot i p) (injQuery i q)
 
 -- | Lifts a value in the `QueryF` algebra into the monad used by a component's
 -- | `eval` function.
-liftQuery :: forall s s' f f' g p p'. (Functor g)
-          => EvalP (QueryF s s' f f' g p p') s s' f f' g p p'
+liftQuery :: forall s s' f f' g p. (Functor g)
+          => EvalP (QueryF s s' f f' g p) s s' f f' g p
 liftQuery qf = liftF (right (right qf))
 
 -- | Installs children into a parent component by using a function that produces
 -- | `ChildState` values for a given slot.
-install :: forall s s' f f' g p p'. (Plus g, Ord p)
-        => ParentComponent s s' f f' g p p'
-        -> (p -> ChildState s' f' g p')
-        -> InstalledComponent s s' f f' g p p'
+install :: forall s s' f f' g p. (Plus g, Ord p)
+        => ParentComponent s s' f f' g p
+        -> (p -> ChildState s' f' g)
+        -> InstalledComponent s s' f f' g p
 install c f = installWithState c (const f)
 
 -- | A version of [`install`](#install) that gives us access to the parent's
 -- | state while installing children.
-installWithState :: forall s s' f f' g p p'. (Plus g, Ord p)
-                 => ParentComponent s s' f f' g p p'
-                 -> (s -> p -> ChildState s' f' g p')
-                 -> InstalledComponent s s' f f' g p p'
+installWithState :: forall s s' f f' g p. (Plus g, Ord p)
+                 => ParentComponent s s' f f' g p
+                 -> (s -> p -> ChildState s' f' g)
+                 -> InstalledComponent s s' f f' g p
 installWithState c f = Component { render: render c f, eval: eval, peek: const (pure unit) }
   where
-  eval :: Eval (Coproduct f (ChildF p f')) (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
+  eval :: Eval (Coproduct f (ChildF p f')) (InstalledState s s' f f' g p) (Coproduct f (ChildF p f')) g
   eval = coproduct (queryParent c) queryChild
 
 -- | A version of [`install`](#install) for use with parent components that
 -- | `peek` on their children.
-install' :: forall s s' f f' g p p'. (Plus g, Ord p)
-        => ParentComponentP s s' f f' g p p'
-        -> (p -> ChildState s' f' g p')
-        -> InstalledComponent s s' f f' g p p'
+install' :: forall s s' f f' g p. (Plus g, Ord p)
+        => ParentComponentP s s' f f' g p
+        -> (p -> ChildState s' f' g)
+        -> InstalledComponent s s' f f' g p
 install' c f = installWithState' c (const f)
 
 -- | A version of [`install'`](#install') that gives us access to the parent's
 -- | state while installing children.
-installWithState' :: forall s s' f f' g p p'. (Plus g, Ord p)
-                  => ParentComponentP s s' f f' g p p'
-                  -> (s -> p -> ChildState s' f' g p')
-                  -> InstalledComponent s s' f f' g p p'
+installWithState' :: forall s s' f f' g p. (Plus g, Ord p)
+                  => ParentComponentP s s' f f' g p
+                  -> (s -> p -> ChildState s' f' g)
+                  -> InstalledComponent s s' f f' g p
 installWithState' c f = Component { render: render c f, eval: eval, peek: const (pure unit) }
   where
-  eval :: Eval (Coproduct f (ChildF p f')) (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
+  eval :: Eval (Coproduct f (ChildF p f')) (InstalledState s s' f f' g p) (Coproduct f (ChildF p f')) g
   eval = coproduct (queryParent c) (\q -> queryChild q <* peek q)
 
-  peek :: PeekP (ChildF p f') (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
+  peek :: PeekP (ChildF p f') (InstalledState s s' f f' g p) (Coproduct f (ChildF p f')) g
   peek q =
     let runSubscribeF' = runSubscribeF (queryParent c)
     in foldFree (coproduct mergeParentStateF (coproduct runSubscribeF' liftChildF)) (peekComponent c q)
 
-mapStateFParent :: forall s s' f f' g p p'. Natural (StateF s) (StateF (InstalledState s s' f f' g p p'))
+mapStateFParent :: forall s s' f f' g p. Natural (StateF s) (StateF (InstalledState s s' f f' g p))
 mapStateFParent = mapState (_.parent) (\f st -> st { parent = f st.parent })
 
-mapStateFChild :: forall s s' f f' g p p'. (Ord p) => p -> Natural (StateF s') (StateF (InstalledState s s' f f' g p p'))
+mapStateFChild :: forall s s' f f' g p. (Ord p) => p -> Natural (StateF s') (StateF (InstalledState s s' f f' g p))
 mapStateFChild p = mapState (\st -> U.fromJust $ snd <$> M.lookup p st.children)
                             (\f st -> { parent: st.parent, children: M.update (Just <<< rmap f) p st.children, memo: st.memo })
 
-render :: forall s s' f f' g o p p'. (Ord p)
-       => ComponentP s f (QueryF s s' f f' g p p') o p
-       -> (s -> p -> ChildState s' f' g p')
-       -> State (InstalledState s s' f f' g p p') (HTML p' ((Coproduct f (ChildF p f')) Unit))
+render :: forall s s' f f' g o p. (Ord p)
+       => ComponentP s f (QueryF s s' f f' g p) o p
+       -> (s -> p -> ChildState s' f' g)
+       -> State (InstalledState s s' f f' g p) (HTML Void ((Coproduct f (ChildF p f')) Unit))
 render c f = do
     st <- CMS.get
     case renderComponent c st.parent of
       Tuple html parentState -> do
         -- Empty the state so that we don't keep children that are no longer
         -- being rendered...
-        CMS.put { parent: parentState, children: M.empty :: M.Map p (ChildState s' f' g p'), memo: M.empty :: M.Map p (HTML p' (Coproduct f (ChildF p f') Unit)) }
+        CMS.put { parent: parentState, children: M.empty :: M.Map p (ChildState s' f' g), memo: M.empty :: M.Map p (HTML Void (Coproduct f (ChildF p f') Unit)) }
         -- ...but then pass through the old state so we can lookup child
         -- components that are being re-rendered
         fillSlot (renderChild st parentState) left html
 
   where
 
-  renderChild :: InstalledState s s' f f' g p p'
+  renderChild :: InstalledState s s' f f' g p
               -> s
               -> p
-              -> State (InstalledState s s' f f' g p p') (HTML p' ((Coproduct f (ChildF p f')) Unit))
+              -> State (InstalledState s s' f f' g p) (HTML Void ((Coproduct f (ChildF p f')) Unit))
   renderChild st parentState p =
     let childState = M.lookup p st.children
     in case M.lookup p st.memo of
       Just html -> do
-        CMS.modify (\st' -> { parent: st'.parent, children: M.alter (const childState) p st'.children, memo: M.insert p html st'.memo } :: InstalledState s s' f f' g p p')
+        CMS.modify (\st' -> { parent: st'.parent, children: M.alter (const childState) p st'.children, memo: M.insert p html st'.memo } :: InstalledState s s' f f' g p)
         pure html
       Nothing -> renderChild' p $ fromMaybe' (\_ -> f parentState p) childState
 
   renderChild' :: p
-               -> ChildState s' f' g p'
-               -> State (InstalledState s s' f f' g p p') (HTML p' ((Coproduct f (ChildF p f')) Unit))
+               -> ChildState s' f' g
+               -> State (InstalledState s s' f f' g p) (HTML Void ((Coproduct f (ChildF p f')) Unit))
   renderChild' p (Tuple c s) = case renderComponent c s of
     Tuple html s' -> do
-      CMS.modify (\st -> { parent: st.parent, children: M.insert p (Tuple c s') st.children, memo: st.memo } :: InstalledState s s' f f' g p p')
+      CMS.modify (\st -> { parent: st.parent, children: M.insert p (Tuple c s') st.children, memo: st.memo } :: InstalledState s s' f f' g p)
       pure $ right <<< ChildF p <$> html
 
-queryParent :: forall s s' f f' g o p p' q. (Functor g)
-            => ComponentP s f (QueryF s s' f f' g p p') o q
-            -> Eval f (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
+queryParent :: forall s s' f f' g o p q. (Functor g)
+            => ComponentP s f (QueryF s s' f f' g p) o q
+            -> Eval f (InstalledState s s' f f' g p) (Coproduct f (ChildF p f')) g
 queryParent c q = foldFree (coproduct mergeParentStateF (coproduct (runSubscribeF (queryParent c)) liftChildF)) (queryComponent c q)
 
-mergeParentStateF :: forall s s' f f' g p p'. Eval (StateF s) (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
+mergeParentStateF :: forall s s' f f' g p. Eval (StateF s) (InstalledState s s' f f' g p) (Coproduct f (ChildF p f')) g
 mergeParentStateF = liftF <<< left <<< mapStateFParent
 
-runSubscribeF :: forall s s' f f' g p p'. (Functor g)
-              => Eval f (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
-              -> Eval (SubscribeF f (Free (HalogenF (InstalledState s s' f f' g p p') (ChildF p f') g))) (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
+runSubscribeF :: forall s s' f f' g p. (Functor g)
+              => Eval f (InstalledState s s' f f' g p) (Coproduct f (ChildF p f')) g
+              -> Eval (SubscribeF f (Free (HalogenF (InstalledState s s' f f' g p) (ChildF p f') g))) (InstalledState s s' f f' g p) (Coproduct f (ChildF p f')) g
 runSubscribeF queryParent' = subscribeN (forever $ lift <<< queryParent' =<< await) <<< hoistSubscribe liftChildF
 
-liftChildF :: forall s s' f f' g p p'. (Functor g)
-           => Eval (Free (HalogenF (InstalledState s s' f f' g p p') (ChildF p f') g)) (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
+liftChildF :: forall s s' f f' g p. (Functor g)
+           => Eval (Free (HalogenF (InstalledState s s' f f' g p) (ChildF p f') g)) (InstalledState s s' f f' g p) (Coproduct f (ChildF p f')) g
 liftChildF = mapF (coproduct left (right <<< coproduct (left <<< remapSubscribe right) right))
 
-queryChild :: forall s s' f f' g p p'. (Plus g, Ord p)
-           => Eval (ChildF p f') (InstalledState s s' f f' g p p') (Coproduct f (ChildF p f')) g
+queryChild :: forall s s' f f' g p. (Plus g, Ord p)
+           => Eval (ChildF p f') (InstalledState s s' f f' g p) (Coproduct f (ChildF p f')) g
 queryChild (ChildF p q) = do
   modify (\st -> { parent: st.parent, children: st.children, memo: M.delete p st.memo })
   mapF (coproduct left (right <<< coproduct (left <<< remapSubscribe right) right)) (mkQuery p q) >>= maybe empty' pure
@@ -363,15 +373,15 @@ transform' sTo sFrom fTo fFrom oFrom tp (Component c) =
   natHF = coproduct (left <<< mapState sFrom (\f s -> sTo (f (sFrom s))))
                     (right <<< coproduct (left <<< remapSubscribe fTo) right)
 
-transform :: forall s s' f f' g p p' q. (Functor g)
+transform :: forall s s' f f' g p p' o q. (Functor g)
           => ChildPath s s' f f' p p'
-          -> Component s f g q
-          -> Component s' f' g q
+          -> ComponentP s f g o q
+          -> ComponentP s' f' g o q
 transform i = transform' (injState i) (U.fromJust <<< prjState i) (injQuery i) (U.fromJust <<< prjQuery i) id id
 
 -- | Changes the component's `g` type. A use case for this would be to interpret
 -- | some `Free` monad as `Aff` so the component can be used with `runUI`.
-interpret :: forall s f g g' p. (Functor g') => Natural g g' -> Component s f g p -> Component s f g' p
+interpret :: forall s f g g' o p. (Functor g') => Natural g g' -> ComponentP s f g o p -> ComponentP s f g' o p
 interpret nat (Component c) =
   Component { render: c.render
             , eval: mapF (hoistHalogenF nat) <<< c.eval

--- a/src/Halogen/Driver.purs
+++ b/src/Halogen/Driver.purs
@@ -48,7 +48,7 @@ type DriverState s =
 -- | can be used to send actions and requests into the component (see the
 -- | [`action`](#action), [`request`](#request), and related variations for
 -- | more details on querying the driver).
-runUI :: forall s f eff. Component s f (Aff (HalogenEffects eff)) Void
+runUI :: forall s f eff. Component s f (Aff (HalogenEffects eff))
       -> s
       -> Aff (HalogenEffects eff) { node :: HTMLElement, driver :: Driver f eff }
 runUI c s = case renderComponent c s of


### PR DESCRIPTION
@jonsterling Here's the removal of the slot type I mentioned that can only be `p` or `Void`.

Cleans up the types a bit, but means I had to introduce `parentComponent` and `parentComponent'` to make the types work... kinda. `component'` can construct any kind of component, but by using the other 3 varieties you get better assistance when it comes to type errors.

Another thought I did consider is doing away with all the varieties and not even distinguishing between peeking and non-peeking components, but instead provide a helper `nopeek = const (pure unit)`. I'm not sure which approach is better.