### PR TITLE
Make slot initialisation lazier

### DIFF
--- a/docs/Halogen/Component.md
+++ b/docs/Halogen/Component.md
@@ -74,7 +74,7 @@ A variation on `Render` for parent components.
 
 ``` purescript
 data SlotConstructor s' f' g p
-  = SlotConstructor p (Component s' f' g) (Unit -> s')
+  = SlotConstructor p (Unit -> { component :: Component s' f' g, initialState :: s' })
 ```
 
 The type used for slots in the HTML rendered by parent components.

--- a/docs/Halogen/HTML.md
+++ b/docs/Halogen/HTML.md
@@ -9,13 +9,13 @@ text :: forall p i. String -> HTML p i
 #### `slot`
 
 ``` purescript
-slot :: forall s f g p i. p -> Component s f g -> (Unit -> s) -> HTML (SlotConstructor s f g p) i
+slot :: forall s f g p i. p -> (Unit -> { component :: Component s f g, initialState :: s }) -> HTML (SlotConstructor s f g p) i
 ```
 
 #### `slot'`
 
 ``` purescript
-slot' :: forall s s' f f' g p p' i. (Functor g) => ChildPath s s' f f' p p' -> p -> Component s f g -> (Unit -> s) -> HTML (SlotConstructor s' f' g p') i
+slot' :: forall s s' f f' g p p' i. (Functor g) => ChildPath s s' f f' p p' -> p -> (Unit -> { component :: Component s f g, initialState :: s }) -> HTML (SlotConstructor s' f' g p') i
 ```
 
 

--- a/examples/ace/src/Main.purs
+++ b/examples/ace/src/Main.purs
@@ -45,7 +45,7 @@ ui = parentComponent' render eval peek
                                       [ H.text "Clear" ]
                            ]
                     ]
-           , H.div_ [ H.slot AceSlot (ace "test-ace") \_ -> initAceState ]
+           , H.div_ [ H.slot AceSlot \_ -> { component: ace "test-ace", initialState: initAceState } ]
            , H.p_ [ H.text ("Current text: " ++ text) ]
            ]
 

--- a/examples/components/src/Main.purs
+++ b/examples/components/src/Main.purs
@@ -8,6 +8,7 @@ import Control.Monad.Eff.Exception (throwException)
 import Control.Plus (Plus)
 
 import Data.Generic (Generic, gEq, gCompare)
+import Data.Lazy (defer)
 import Data.Maybe (Maybe(..), maybe)
 
 import Halogen
@@ -36,9 +37,11 @@ ui = parentComponent' render eval (const (pure unit))
 
   render :: RenderParent State TickState Input TickInput g TickSlot
   render st =
-    H.div_ [ H.slot (TickSlot "A") ticker \_ -> TickState 100
-           , H.slot (TickSlot "B") ticker \_ -> TickState 0
-           , H.p_ [ H.p_ [ H.text $ "Last tick readings - A: " ++ (maybe "No reading" show st.tickA) ++ ", B: " ++ (maybe "No reading" show st.tickB) ]
+    H.div_ [ H.slot (TickSlot "A") \_ -> { component: ticker, initialState: TickState 100 }
+           , H.slot (TickSlot "B") \_ -> { component: ticker, initialState: TickState 0 }
+           , H.p_ [ H.p_ [ H.text $ "Last tick readings - A: " ++ (maybe "No reading" show st.tickA)
+                                                    ++ ", B: " ++ (maybe "No reading" show st.tickB)
+                         ]
                   , H.button [ E.onClick (E.input_ ReadTicks) ]
                              [ H.text "Update reading" ]
                   ]

--- a/examples/multi-component/src/Main.purs
+++ b/examples/multi-component/src/Main.purs
@@ -48,9 +48,9 @@ ui = parentComponent' render eval (const (pure unit))
 
   render :: RenderParent State ChildStates Input ChildInputs g ChildSlots
   render (State state) = H.div_
-    [ H.div_ [ H.slot' cpA SlotA componentA \_ -> initStateA ]
-    , H.div_ [ H.slot' cpB SlotB componentB \_ -> initStateB ]
-    , H.div_ [ H.slot' cpC SlotC componentC \_ -> initStateC ]
+    [ H.div_ [ H.slot' cpA SlotA \_ -> { component: componentA, initialState: initStateA } ]
+    , H.div_ [ H.slot' cpB SlotB \_ -> { component: componentB, initialState: initStateB } ]
+    , H.div_ [ H.slot' cpC SlotC \_ -> { component: componentC, initialState: initStateC } ]
     , H.div_ [ H.text $ "Current states: " ++ show state.a ++ " / " ++ show state.b ++ " / " ++ show state.c ]
     , H.button [ E.onClick (E.input_ ReadStates) ] [ H.text "Read states" ]
     ]

--- a/examples/todo/src/Component/List.purs
+++ b/examples/todo/src/Component/List.purs
@@ -37,9 +37,12 @@ list = parentComponent' render eval peek
            , H.p_ [ H.button [ E.onClick (E.input_ NewTask) ]
                              [ H.text "New Task" ]
                   ]
-           , H.ul_ (map (\tid -> H.slot (TaskSlot tid) task \_ -> initialTask) st.tasks)
+           , H.ul_ (map renderTask st.tasks)
            , H.p_ [ H.text $ show st.numCompleted ++ " / " ++ show (length st.tasks) ++ " complete" ]
            ]
+
+  renderTask :: TaskId -> HTML (SlotConstructor Task TaskInput g TaskSlot) ListInput
+  renderTask taskId = H.slot (TaskSlot taskId) \_ -> { component: task, initialState: initialTask }
 
   eval :: EvalParent ListInput State Task ListInput TaskInput g TaskSlot
   eval (NewTask next) = do

--- a/src/Halogen/HTML.purs
+++ b/src/Halogen/HTML.purs
@@ -4,28 +4,33 @@ module Halogen.HTML
   , module Halogen.HTML.Elements
   ) where
 
-import Prelude ((<<<), Unit(), unit, Functor)
+import Prelude ((<<<), Unit(), unit, Functor, (<$>))
+
 import Data.Bifunctor (bimap)
-import Halogen.HTML.Core
-import Halogen.HTML.Elements
+
 import Halogen.Component (Component(), SlotConstructor(..), transformChild)
 import Halogen.Component.ChildPath (ChildPath(), injSlot, injState)
+import Halogen.HTML.Core
+import Halogen.HTML.Elements
 
 text :: forall p i. String -> HTML p i
 text = Text
 
 slot :: forall s f g p i
       . p
-     -> Component s f g
-     -> (Unit -> s)
+     -> (Unit -> { component :: Component s f g, initialState :: s })
      -> HTML (SlotConstructor s f g p) i
-slot p c s = Slot (SlotConstructor p c s)
+slot p l = Slot (SlotConstructor p l)
 
 slot' :: forall s s' f f' g p p' i
        . (Functor g)
       => ChildPath s s' f f' p p'
       -> p
-      -> Component s f g
-      -> (Unit -> s)
+      -> (Unit -> { component :: Component s f g, initialState :: s })
       -> HTML (SlotConstructor s' f' g p') i
-slot' i p c s = Slot (SlotConstructor (injSlot i p) (transformChild i c) (\_ -> injState i (s unit)))
+slot' i p l = Slot (SlotConstructor (injSlot i p) (transform <$> l))
+  where
+  transform def =
+    { component: transformChild i def.component
+    , initialState: injState i def.initialState
+    }


### PR DESCRIPTION
I tried to use `Lazy` here rather than a naked thunk, but unfortunately the type checker couldn't deal with that when you have a `ParentComponent` with a polymorphic `g`:

```
Cannot unify constrained type
    (Prelude.Functor g0) => Halogen.Component.Component<Example.Components.Ticker.TickState,Example.Components.Ticker.TickInput,g0>
  with type
    Halogen.Component.ComponentP _1 _2 _3 (Data.Const.Const Data.Void.Void) Data.Void.Void
```

A shame... but aside from that I prefer this tweaked approach for two reasons: 

1. It means we don't have to pay when defining the `HTML` if a child component is constructed rather than being a reference.
2. Making it a record with a field named `initialState` reinforces the fact that you cannot change the child component's state by altering this value alone.

I think this is the last change I want to make to the code for 0.5. I just need to update the documentation now, and rework some sections of the README to reflect these install changes. I'll make one last PR with all that stuff in together.

@jonsterling @beckyconning @cryogenian 