### PR TITLE
Remove memo key from lifecycle props

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ The [Ace editor exampe](examples/ace) illustrates the creation of a basic widget
 
 A widget is constructed using the standard `component` function but taking advantage of some features that are not used when defining a normal component.
 
-Even though we’re embedding an external component in our page we still need to render a `HTML` value, so the suggested way of doing this is to generate a single empty element such as a `div` and then attach the special `Initializer` property to it to handle setup once the element has been rendered to the page. From the Ace example:
+Even though we’re embedding an external component in our page we still need to render a `HTML` value, so the suggested way of doing this is to generate a single empty element such as a `div` and then attach the special `initializer` property to it to handle setup once the element has been rendered to the page. From the Ace example:
 
 ``` purescript
 ace :: forall eff. String -> Component AceState AceQuery (Aff (AceEffects eff))
@@ -506,14 +506,10 @@ The `Initializer` property allows us to define an action that will run on the wi
 
 ``` purescript
 initializer :: Prop AceQuery
-initializer = H.Initializer ("ace-" ++ key ++ "-init") (\el -> action (Init el))
+initializer = P.initializer \el -> action (Init el)
 ```
 
-We also have to pass a string key for the initializer that is used to memoize the result. This is an unfortunate implementation detail Halogen exposes that is prone to unexpected behaviour if used improperly – it is important to ensure that every `Initializer` in a component hierarchy has a unique value. 
-
-In the Ace example we achieve this by accepting a `key` value when constructing the widget and build this into the `Initializer` key - the idea being the parent could provide a unique key for each instance of the Ace editor that it embeds.
-
-There is also a `Finalizer` property that works in a similar way to the `Initializer` but runs when the rendered HTML element is being removed from the DOM instead, to allow any cleanup that may be required when removing the widget.
+There is also a `finalizer` property that works in a similar way to the `initializer` but runs when the rendered HTML element is being removed from the DOM instead, to allow any cleanup that may be required when removing the widget.
 
 #### Initializing the widget
 

--- a/examples/ace/src/AceComponent.purs
+++ b/examples/ace/src/AceComponent.purs
@@ -46,10 +46,8 @@ ace key = component render eval
   render :: Render AceState AceQuery
   render = const $ H.div [ initializer ] []
 
-  -- Setup the initializer property that will raise the `Init` action in `eval`
-  -- once our placeholder div has been added to the DOM.
-  initializer :: Prop AceQuery
-  initializer = H.Initializer ("ace-" ++ key ++ "-init") (\el -> action (Init el))
+  initializer :: Prop AceInput
+  initializer = H.Initializer \el -> action (Init el)
 
   -- The query algebra for the component handles the initialization of the Ace
   -- editor as well as responding to the `ChangeText` action that allows us to

--- a/examples/ace/src/AceComponent.purs
+++ b/examples/ace/src/AceComponent.purs
@@ -13,6 +13,7 @@ import DOM.HTML.Types (HTMLElement())
 
 import Halogen
 import qualified Halogen.HTML as H
+import qualified Halogen.HTML.Properties as P
 
 import Ace.Types (ACE(), Editor())
 import qualified Ace.Editor as Editor
@@ -37,8 +38,8 @@ type AceEffects eff = (ace :: ACE, avar :: AVAR | eff)
 -- | The Ace component definition. We accept a key here to give each instance
 -- | of the ace component a unique initializer key - recycling an initializer
 -- | may result in unexpected behaviours.
-ace :: forall eff. String -> Component AceState AceQuery (Aff (AceEffects eff))
-ace key = component render eval
+ace :: forall eff. Component AceState AceQuery (Aff (AceEffects eff))
+ace = component render eval
   where
 
   -- As we're embedding a 3rd party component we only need to create a
@@ -46,8 +47,8 @@ ace key = component render eval
   render :: Render AceState AceQuery
   render = const $ H.div [ initializer ] []
 
-  initializer :: Prop AceInput
-  initializer = H.Initializer \el -> action (Init el)
+  initializer :: Prop AceQuery
+  initializer = P.initializer \el -> action (Init el)
 
   -- The query algebra for the component handles the initialization of the Ace
   -- editor as well as responding to the `ChangeText` action that allows us to

--- a/examples/ace/src/Main.purs
+++ b/examples/ace/src/Main.purs
@@ -51,7 +51,7 @@ ui = parentComponent' render eval peek
                                       [ H.text "Clear" ]
                            ]
                     ]
-           , H.div_ [ H.slot AceSlot \_ -> { component: ace "test-ace", initialState: initAceState } ]
+           , H.div_ [ H.slot AceSlot \_ -> { component: ace, initialState: initAceState } ]
            , H.p_ [ H.text ("Current text: " ++ text) ]
            ]
 

--- a/examples/lifecycle/.gitignore
+++ b/examples/lifecycle/.gitignore
@@ -1,0 +1,3 @@
+/dist/example.js
+/output
+/bower_components

--- a/examples/lifecycle/bower.json
+++ b/examples/lifecycle/bower.json
@@ -1,0 +1,7 @@
+{
+  "name": "intro",
+  "private": true,
+  "dependencies": {
+    "purescript-halogen": "*"
+  }
+}

--- a/examples/lifecycle/dist/index.html
+++ b/examples/lifecycle/dist/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:foo="http://www.w3.org/2000/svg">
+  <head>
+    <title>Halogen Example - Lifecycle</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        max-width: 800px;
+        margin: auto;
+      }
+    </style>
+  </head>
+  <body>
+    <script src="example.js"></script>
+  </body>
+</html>

--- a/examples/lifecycle/gulpfile.js
+++ b/examples/lifecycle/gulpfile.js
@@ -1,0 +1,40 @@
+/* jshint node: true */
+"use strict";
+
+var gulp = require("gulp");
+var purescript = require("gulp-purescript");
+var webpack = require("webpack-stream");
+
+var sources = [
+  "src/**/*.purs",
+  "bower_components/purescript-*/src/**/*.purs"
+];
+
+var foreigns = [
+  "bower_components/purescript-*/src/**/*.js"
+];
+
+gulp.task("make", function() {
+  return purescript.psc({ src: sources, ffi: foreigns });
+});
+
+gulp.task("prebundle", ["make"], function() {
+  return purescript.pscBundle({
+    src: "output/**/*.js",
+    output: "dist/example.js",
+    module: "Example.Lifecycle",
+    main: "Example.Lifecycle"
+  });
+});
+
+gulp.task("bundle", ["prebundle"], function () {
+  return gulp.src("dist/example.js")
+    .pipe(webpack({
+      resolve: { modulesDirectories: ["node_modules"] },
+      output: { filename: "example.js" }
+    }))
+    .pipe(gulp.dest("dist"));
+});
+
+gulp.task("default", ["bundle"]);
+

--- a/examples/lifecycle/src/Main.purs
+++ b/examples/lifecycle/src/Main.purs
@@ -1,0 +1,53 @@
+module Example.Lifecycle where
+
+import Prelude
+
+import Control.Monad.Aff (runAff)
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Exception (throwException)
+
+import Halogen
+import Halogen.Util (appendToBody)
+import qualified Halogen.HTML.Indexed as H
+import qualified Halogen.HTML.Properties.Indexed as P
+import qualified Halogen.HTML.Events.Indexed as E
+
+-- | The state of the application
+type State = { events :: Array String, on :: Boolean }
+
+initialState :: State
+initialState = { events: [], on: true }
+
+-- | Inputs to the state machine
+data Input a = ToggleState a
+             | AddEvent String a
+
+ui :: forall g. (Functor g) => Component State Input g
+ui = component render eval
+  where
+
+  render :: Render State Input
+  render state = H.div_
+    [ H.h1_ [ H.text "Toggle Button" ]
+    , H.button [ E.onClick (E.input_ ToggleState) ]
+               [ H.text (if state.on then "Hide" else "Show") ]
+    , if state.on
+         then H.span [ P.initializer \_ -> action (AddEvent "Initialized")
+                     , P.finalizer \_ -> action (AddEvent "Finalized") ]
+                     [ H.text "Hello, World!" ]
+         else H.text ""
+    , H.ul_ (map (\event -> H.li_ [ H.text event ]) state.events)
+    ]
+
+  eval :: Eval Input State Input g
+  eval (ToggleState next) = do
+    modify (\state -> state { on = not state.on })
+    pure next
+  eval (AddEvent event next) = do
+    modify (\state -> state { events = state.events <> [event] })
+    pure next
+
+main :: Eff (HalogenEffects ()) Unit
+main = runAff throwException (const (pure unit)) $ do
+  app <- runUI ui initialState
+  appendToBody app.node

--- a/examples/lifecycle/src/Main.purs
+++ b/examples/lifecycle/src/Main.purs
@@ -18,15 +18,15 @@ type State = { events :: Array String, on :: Boolean }
 initialState :: State
 initialState = { events: [], on: true }
 
--- | Inputs to the state machine
-data Input a = ToggleState a
+-- | Queries to the state machine
+data Query a = ToggleState a
              | AddEvent String a
 
-ui :: forall g. (Functor g) => Component State Input g
+ui :: forall g. (Functor g) => Component State Query g
 ui = component render eval
   where
 
-  render :: Render State Input
+  render :: Render State Query
   render state = H.div_
     [ H.h1_ [ H.text "Toggle Button" ]
     , H.button [ E.onClick (E.input_ ToggleState) ]
@@ -39,7 +39,7 @@ ui = component render eval
     , H.ul_ (map (\event -> H.li_ [ H.text event ]) state.events)
     ]
 
-  eval :: Eval Input State Input g
+  eval :: Eval Query State Query g
   eval (ToggleState next) = do
     modify (\state -> state { on = not state.on })
     pure next
@@ -48,6 +48,6 @@ ui = component render eval
     pure next
 
 main :: Eff (HalogenEffects ()) Unit
-main = runAff throwException (const (pure unit)) $ do
+main = runAff throwException (const (pure unit)) do
   app <- runUI ui initialState
   appendToBody app.node

--- a/src/Halogen/HTML/Core.purs
+++ b/src/Halogen/HTML/Core.purs
@@ -99,16 +99,16 @@ data Prop i
   | Attr (Maybe Namespace) AttrName String
   | Key String
   | Handler (ExistsR (HandlerF i))
-  | Initializer String (HTMLElement -> i)
-  | Finalizer String (HTMLElement -> i)
+  | Initializer (HTMLElement -> i)
+  | Finalizer (HTMLElement -> i)
 
 instance functorProp :: Functor Prop where
   map _ (Prop e) = Prop e
   map _ (Key k) = Key k
   map _ (Attr ns k v) = Attr ns k v
   map f (Handler e) = runExistsR (\(HandlerF name k) -> Handler (mkExistsR (HandlerF name (map (map f) <<< k)))) e
-  map f (Initializer k g) = Initializer k (f <<< g)
-  map f (Finalizer k g) = Finalizer k (f <<< g)
+  map f (Initializer g) = Initializer (f <<< g)
+  map f (Finalizer g) = Finalizer (f <<< g)
 
 -- | The data which represents a typed property, hidden inside an existential
 -- | package in the `Prop` type.

--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -27,6 +27,8 @@ module Halogen.HTML.Properties
   , checked
   , selected
   , placeholder
+  , initializer
+  , finalizer
   , LengthLiteral(..)
   ) where
 
@@ -34,6 +36,8 @@ import Prelude
 
 import Data.Maybe (Maybe(..))
 import Data.String (joinWith)
+
+import DOM.HTML.Types (HTMLElement())
 
 import Halogen.HTML.Core (Prop(..), ClassName(), IsProp, prop, propName, attrName, runClassName)
 import Halogen.HTML.Events.Types (Event())
@@ -132,3 +136,9 @@ selected = prop (propName "selected") (Just $ attrName "selected")
 
 placeholder :: forall i. String -> Prop i
 placeholder = prop (propName "placeholder") (Just $ attrName "placeholder")
+
+initializer :: forall i. (HTMLElement -> i) -> Prop i
+initializer = Initializer
+
+finalizer :: forall i. (HTMLElement -> i) -> Prop i
+finalizer = Finalizer

--- a/src/Halogen/HTML/Properties/Indexed.purs
+++ b/src/Halogen/HTML/Properties/Indexed.purs
@@ -51,6 +51,9 @@ module Halogen.HTML.Properties.Indexed
   , selected
   , placeholder
 
+  , initializer
+  , finalizer
+
   , module PExport
 
   , GlobalAttributes()
@@ -66,6 +69,7 @@ import Prelude
 import Data.Tuple
 import Data.Foldable
 import qualified Data.Array as A
+import DOM.HTML.Types (HTMLElement())
 import qualified Halogen.HTML.Properties as P
 import qualified Halogen.HTML.Properties (LengthLiteral(..)) as PExport
 import qualified Halogen.HTML.Properties.Indexed.Unsafe as Unsafe
@@ -313,6 +317,12 @@ selected = refine <<< P.selected
 placeholder :: forall r i. String -> IProp (placeholder :: I | r) i
 placeholder = refine <<< P.placeholder
 
+initializer :: forall r i. (HTMLElement -> i) -> IProp (initializer :: I | r) i
+initializer = refine <<< P.initializer
+
+finalizer :: forall r i. (HTMLElement -> i) -> IProp (finalizer :: I | r) i
+finalizer = refine <<< P.finalizer
+
 type GlobalAttributes r =
   ( id :: I
   , name :: I
@@ -320,6 +330,8 @@ type GlobalAttributes r =
   , class :: I
   , spellcheck :: I
   , key :: I
+  , initializer :: I
+  , finalizer :: I
   | r
   )
 

--- a/src/Halogen/HTML/Renderer/VirtualDOM.purs
+++ b/src/Halogen/HTML/Renderer/VirtualDOM.purs
@@ -1,7 +1,5 @@
 module Halogen.HTML.Renderer.VirtualDOM
-  ( RenderState()
-  , renderHTML
-  , emptyRenderState
+  ( renderHTML
   ) where
 
 import Prelude
@@ -16,7 +14,7 @@ import Control.Monad.State.Class (gets, modify)
 
 import Data.Exists (runExists)
 import Data.ExistsR (runExistsR)
-import Data.Foldable (foldl, fold, find)
+import Data.Foldable (foldl, fold, foldMap, find)
 import Data.Function (runFn2)
 import Data.List (List(..), (:))
 import Data.Maybe (Maybe(..), maybe, isNothing)
@@ -34,69 +32,32 @@ import Halogen.HTML.Core (HTML(..), Prop(..), PropF(..), HandlerF(..), runNamesp
 import Halogen.HTML.Events.Handler (runEventHandler)
 import qualified Halogen.Internal.VirtualDOM as V
 
-type RenderState =
-  { initializers :: SM.StrMap V.Props
-  , finalizers :: SM.StrMap V.Props
-  }
-
-emptyRenderState :: RenderState
-emptyRenderState = { initializers: mempty, finalizers: mempty }
-
 -- | Render a `HTML` document to a virtual DOM node
 -- |
 -- | The first argument is an event handler.
-renderHTML :: forall p f eff. (forall i. f i -> Aff (HalogenEffects eff) i) -> HTML p (f Unit) -> RenderState -> Tuple V.VTree RenderState
-renderHTML f html st = runState (go html) emptyRenderState
+renderHTML :: forall p f eff. (forall i. f i -> Aff (HalogenEffects eff) i) -> HTML p (f Unit) -> V.VTree
+renderHTML f = go
   where
-  go :: HTML p (f Unit) -> State RenderState V.VTree
-  go (Text s) = pure $ V.vtext s
-  go (Element ns name props els) = do
+  go :: HTML p (f Unit) -> V.VTree
+  go (Text s) = V.vtext s
+  go (Element ns name props els) =
       let ns' = toNullable $ runNamespace <$> ns
           tag = runTagName name
           key = toNullable $ foldl findKey Nothing props
-      V.vnode ns' tag key <$> (fold <$> traverse (renderProp f st) props)
-                          <*> traverse go els
-  go (Slot _) = pure $ V.vtext ""
+      in V.vnode ns' tag key (foldMap (renderProp f) props) (map go els)
+  go (Slot _) = V.vtext ""
 
-renderProp :: forall f eff. (forall i. f i -> Aff (HalogenEffects eff) i) -> RenderState -> Prop (f Unit) -> State RenderState V.Props
-renderProp _ _ (Prop e) = pure $ runExists (\(PropF key value _) ->
+renderProp :: forall f eff. (forall i. f i -> Aff (HalogenEffects eff) i) -> Prop (f Unit) -> V.Props
+renderProp _ (Prop e) = runExists (\(PropF key value _) ->
   runFn2 V.prop (runPropName key) value) e
-renderProp _ _ (Attr ns name value) =
+renderProp _ (Attr ns name value) =
   let attrName = maybe "" (\ns' -> runNamespace ns' <> ":") ns <> runAttrName name
-  in pure $ runFn2 V.attr attrName value
-renderProp dr _ (Handler e) = pure $ runExistsR (\(HandlerF name k) ->
+  in runFn2 V.attr attrName value
+renderProp dr (Handler e) = runExistsR (\(HandlerF name k) ->
   runFn2 V.handlerProp (runEventName name) \ev -> handleAff $ runEventHandler ev (k ev) >>= maybe (pure unit) dr) e
-renderProp dr st (Initializer k f) = ifprop st (_.initializers) (\is -> _ { initializers = is }) k V.initProp dr f
-renderProp dr st (Finalizer k f) = ifprop st (_.finalizers) (\fs -> _ { finalizers = fs }) k V.finalizerProp dr f
-renderProp _ _ _ = pure mempty
-
--- | Creates a initializer/finalizer if required, or returns a previously
--- | memoized version if one exists.
--- |
--- | Even though the previous `RenderState` is passed in to perform the lookup,
--- | we also need to check the currently accumulating `RenderState` - if an
--- | initializer/finalizer is used in more than one place in the current HTML
--- | structure we don't want to clobber previously memoized versions of it in
--- | the current render cycle.
--- |
--- | TODO: use ST StrMap?
-ifprop :: forall eff f. RenderState
-                     -> (RenderState -> SM.StrMap V.Props)
-                     -> (SM.StrMap V.Props -> RenderState -> RenderState)
-                     -> String
-                     -> ((HTMLElement -> Eff (HalogenEffects eff) Unit) -> V.Props)
-                     -> (f Unit -> Aff (HalogenEffects eff) Unit)
-                     -> (HTMLElement -> f Unit)
-                     -> State RenderState V.Props
-ifprop oldState getter modifier key mkProp dr f = do
-  currentState <- gets getter
-  let lastMemo = SM.lookup key (getter oldState)
-      currentMemo = SM.lookup key currentState
-      prop = case lastMemo <|> currentMemo of
-        Nothing -> mkProp (handleAff <<< dr <<< f)
-        Just prop' -> prop'
-  when (isNothing currentMemo) $ modify (modifier (SM.insert key prop currentState))
-  pure prop
+renderProp dr (Initializer f) = V.initProp (handleAff <<< dr <<< f)
+renderProp dr (Finalizer f) = V.finalizerProp (handleAff <<< dr <<< f)
+renderProp _ _ = mempty
 
 handleAff :: forall eff a. Aff (HalogenEffects eff) a -> Eff (HalogenEffects eff) Unit
 handleAff = runAff throwException (const (pure unit))

--- a/src/Halogen/HTML/Renderer/VirtualDOM.purs
+++ b/src/Halogen/HTML/Renderer/VirtualDOM.purs
@@ -4,28 +4,17 @@ module Halogen.HTML.Renderer.VirtualDOM
 
 import Prelude
 
-import Control.Alt ((<|>))
-import Control.Monad (when)
 import Control.Monad.Aff (Aff(), runAff)
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Exception (throwException)
-import Control.Monad.State (State(), runState)
-import Control.Monad.State.Class (gets, modify)
 
 import Data.Exists (runExists)
 import Data.ExistsR (runExistsR)
-import Data.Foldable (foldl, fold, foldMap, find)
+import Data.Foldable (foldl, foldMap)
 import Data.Function (runFn2)
-import Data.List (List(..), (:))
-import Data.Maybe (Maybe(..), maybe, isNothing)
+import Data.Maybe (Maybe(..), maybe)
 import Data.Monoid (mempty)
-import Data.NaturalTransformation (Natural())
 import Data.Nullable (toNullable)
-import Data.Traversable (traverse)
-import Data.Tuple (Tuple(..), fst)
-import qualified Data.StrMap as SM
-
-import DOM.HTML.Types (HTMLElement())
 
 import Halogen.Effects (HalogenEffects())
 import Halogen.HTML.Core (HTML(..), Prop(..), PropF(..), HandlerF(..), runNamespace, runTagName, runPropName, runAttrName, runEventName)


### PR DESCRIPTION
The cleans up the lifecycle hooks so they don't need a memo key.

Virtual-dom provides a third parameter to `hook`/`unhook` that tells you which hook it is transitioning from or to. When it has not transitioned from another hook, we can call the initializer. And when it is not transitioning to another hook, we can call the finalizer.

As far as I can tell, this works fine. Both the ace example, and a new example I added, work as expected and you don't get the infinite recursion.

I also added `initializer`/`finalizer` to `Properties` and created `Indexed` variants of them. Previously you couldn't use them as-is with the `Indexed` HTML elements.