### PR TITLE
Added appendTo to Halogen.Util

### DIFF
--- a/src/Halogen/Util.purs
+++ b/src/Halogen/Util.purs
@@ -36,11 +36,7 @@ appendTo query e = onLoad $ \_ -> do
 -- | A utility for appending an `HTMLElement` to the current document's `body`
 -- | element once the document has loaded.
 appendToBody :: forall m eff. (MonadEff (dom :: DOM | eff) m) => HTMLElement -> m Unit
-appendToBody e = onLoad $ \_ -> do
-    b <- toMaybe <$> ((body <=< document) =<< window)
-    case b of
-      Nothing -> pure unit
-      Just b' -> void $ appendChild (htmlElementToNode e) (htmlElementToNode b')
+appendToBody = appendTo "body"
 
 onLoad :: forall m eff. (MonadEff (dom :: DOM | eff) m)
        => (Event -> Eff (dom :: DOM | eff) Unit) -> m Unit

--- a/src/Halogen/Util.purs
+++ b/src/Halogen/Util.purs
@@ -1,4 +1,7 @@
-module Halogen.Util where
+module Halogen.Util
+  ( appendTo
+  , appendToBody
+  ) where
 
 import Prelude
 
@@ -15,19 +18,31 @@ import DOM.Event.EventTypes (load)
 import DOM.Event.Types (Event())
 import DOM.HTML (window)
 import DOM.HTML.Document (body)
-import DOM.HTML.Types (HTMLElement(), htmlElementToNode, windowToEventTarget)
+import DOM.HTML.Types (HTMLElement(), htmlElementToNode, windowToEventTarget, htmlDocumentToParentNode)
 import DOM.HTML.Window (document)
 import DOM.Node.Node (appendChild)
+import DOM.Node.ParentNode (querySelector)
+import DOM.Node.Types (elementToNode)
+
+-- | A utility for appending an `HTMLElement` to the element selected using querySelector
+-- | element once the document has loaded.
+appendTo :: forall m eff. (MonadEff (dom :: DOM | eff) m)  => String -> HTMLElement -> m Unit
+appendTo query e = onLoad $ \_ -> do
+    b <- toMaybe <$> ((querySelector query <<< htmlDocumentToParentNode <=< document) =<< window)
+    case b of
+      Nothing -> pure unit
+      Just b' -> void $ appendChild (htmlElementToNode e) (elementToNode b')
 
 -- | A utility for appending an `HTMLElement` to the current document's `body`
 -- | element once the document has loaded.
 appendToBody :: forall m eff. (MonadEff (dom :: DOM | eff) m) => HTMLElement -> m Unit
-appendToBody e = liftEff $ do
-  addEventListener load (eventListener onLoad) false <<< windowToEventTarget =<< window
-  where
-  onLoad :: forall eff. Event -> Eff (dom :: DOM | eff) Unit
-  onLoad _ = do
+appendToBody e = onLoad $ \_ -> do
     b <- toMaybe <$> ((body <=< document) =<< window)
     case b of
       Nothing -> pure unit
       Just b' -> void $ appendChild (htmlElementToNode e) (htmlElementToNode b')
+
+onLoad :: forall m eff. (MonadEff (dom :: DOM | eff) m)
+       => (Event -> Eff (dom :: DOM | eff) Unit) -> m Unit
+onLoad callback = liftEff $ do
+  addEventListener load (eventListener callback) false <<< windowToEventTarget =<< window


### PR DESCRIPTION
Users often might want to append to something else than `body`.

Of course the problem of "Get an element and append another element to it", should be solved by some other libraries (purescript-simple-dom, purescript-jquery), but it seems that at the moment we end up with `purescript-dom` which is a bit unwieldy for such a simple task.