### PR TITLE
Finer grained synonyms for better reusability

### DIFF
--- a/docs/Halogen/Util.md
+++ b/docs/Halogen/Util.md
@@ -1,5 +1,14 @@
 ## Module Halogen.Util
 
+#### `appendTo`
+
+``` purescript
+appendTo :: forall m eff. (MonadEff (dom :: DOM | eff) m) => String -> HTMLElement -> m Unit
+```
+
+A utility for appending an `HTMLElement` to the element selected using querySelector
+element once the document has loaded.
+
 #### `appendToBody`
 
 ``` purescript

--- a/examples/todo/src/Component/List.purs
+++ b/examples/todo/src/Component/List.purs
@@ -9,6 +9,7 @@ import Data.Array (snoc, filter, length)
 import Data.Functor.Coproduct (Coproduct())
 import Data.Generic (Generic, gEq, gCompare)
 import Data.Maybe (Maybe(..), fromMaybe)
+import Data.NaturalTransformation (Natural())
 
 import Halogen
 import qualified Halogen.HTML.Indexed as H
@@ -35,7 +36,7 @@ list :: forall g. (Plus g) => Component (State g) Query g
 list = parentComponent' render eval peek
   where
 
-  render :: RenderParent List Task ListQuery TaskQuery g TaskSlot
+  render :: List -> ParentHTML Task ListQuery TaskQuery g TaskSlot
   render st =
     H.div_ [ H.h1_ [ H.text "Todo list" ]
            , H.p_ [ H.button [ E.onClick (E.input_ NewTask) ]
@@ -45,15 +46,15 @@ list = parentComponent' render eval peek
            , H.p_ [ H.text $ show st.numCompleted ++ " / " ++ show (length st.tasks) ++ " complete" ]
            ]
 
-  renderTask :: TaskId -> HTML (SlotConstructor Task TaskQuery g TaskSlot) ListQuery
+  renderTask :: TaskId -> ParentHTML Task ListQuery TaskQuery g TaskSlot
   renderTask taskId = H.slot (TaskSlot taskId) \_ -> { component: task, initialState: initialTask }
 
-  eval :: EvalParent ListQuery List Task ListQuery TaskQuery g TaskSlot
+  eval :: Natural ListQuery (ParentDSL List Task ListQuery TaskQuery g TaskSlot)
   eval (NewTask next) = do
     modify addTask
     pure next
 
-  peek :: Peek (ChildF TaskSlot TaskQuery) List Task ListQuery TaskQuery g TaskSlot
+  peek :: forall a. ChildF TaskSlot TaskQuery a -> ParentDSL List Task ListQuery TaskQuery g TaskSlot Unit
   peek (ChildF p q) = case q of
     Remove _ -> do
       wasComplete <- query p (request IsCompleted)

--- a/examples/todo/src/Component/Task.purs
+++ b/examples/todo/src/Component/Task.purs
@@ -2,6 +2,8 @@ module Component.Task where
 
 import Prelude
 
+import Data.NaturalTransformation (Natural())
+
 import Halogen
 import qualified Halogen.HTML.Indexed as H
 import qualified Halogen.HTML.Properties.Indexed as P
@@ -21,7 +23,7 @@ task :: forall g. (Functor g) => Component Task TaskQuery g
 task = component render eval
   where
 
-  render :: Render Task TaskQuery
+  render :: Task -> ComponentHTML TaskQuery
   render t =
     H.li_ [ H.input [ P.inputType P.InputCheckbox
                     , P.title "Mark as completed"
@@ -39,7 +41,7 @@ task = component render eval
                      [ H.text "✖" ]
           ]
 
-  eval :: Eval TaskQuery Task TaskQuery g
+  eval :: Natural TaskQuery (ComponentDSL Task TaskQuery g)
   eval (UpdateDescription desc next) = do
     modify (_ { description = desc })
     pure next


### PR DESCRIPTION
This keeps the old `Render` etc. synonyms but introduces new synonyms that are helpful for cases where you have `render`, `peek`, or `eval` split over multiple functions.