### PR TITLE
Component transforms

### DIFF
--- a/docs/Halogen/Component.md
+++ b/docs/Halogen/Component.md
@@ -238,6 +238,12 @@ liftQuery :: forall s s' f f' g p. (Functor g) => EvalParent (QueryF s s' f f' g
 Lifts a value in the `QueryF` algebra into the monad used by a component's
 `eval` function.
 
+#### `transform`
+
+``` purescript
+transform :: forall s s' f f' g. (Functor g) => (s -> s') -> (s' -> s) -> Natural f f' -> Natural f' f -> Component s f g -> Component s' f' g
+```
+
 #### `transformChild`
 
 ``` purescript

--- a/docs/Halogen/Component.md
+++ b/docs/Halogen/Component.md
@@ -96,10 +96,18 @@ same form but the type representation is different.
 
 ``` purescript
 data SlotConstructor s' f' g p
-  = SlotConstructor p (Unit -> { component :: Component s' f' g, initialState :: s' })
 ```
 
 The type used for slots in the HTML rendered by parent components.
+
+#### `slotConstructor`
+
+``` purescript
+slotConstructor :: forall s f g p. p -> (Unit -> { component :: Component s f g, initialState :: s }) -> SlotConstructor s f g p
+```
+
+Creates a `SlotConstructor` from a slot address value and thunked
+constructor.
 
 #### `ParentDSL`
 
@@ -243,6 +251,8 @@ Lifts a value in the `QueryF` algebra into the monad used by a component's
 ``` purescript
 transform :: forall s s' f f' g. (Functor g) => (s -> s') -> (s' -> s) -> Natural f f' -> Natural f' f -> Component s f g -> Component s' f' g
 ```
+
+Transforms a `Component`'s types.
 
 #### `transformChild`
 

--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -8,7 +8,8 @@ module Halogen.Component
   , component
   , ParentHTML()
   , RenderParent()
-  , SlotConstructor(..)
+  , SlotConstructor()
+  , slotConstructor
   , ParentDSL()
   , EvalParent()
   , Peek()
@@ -123,6 +124,14 @@ type RenderParent s s' f f' g p = s -> ParentHTML s' f f' g p
 
 -- | The type used for slots in the HTML rendered by parent components.
 data SlotConstructor s' f' g p = SlotConstructor p (Unit -> { component :: Component s' f' g, initialState :: s' })
+
+-- | Creates a `SlotConstructor` from a slot address value and thunked
+-- | constructor.
+slotConstructor :: forall s f g p
+                 . p
+                -> (Unit -> { component :: Component s f g, initialState :: s })
+                -> SlotConstructor s f g p
+slotConstructor = SlotConstructor
 
 -- | The DSL used in the `eval` and `peek` functions for parent components.
 type ParentDSL s s' f f' g p = ComponentDSL s f (QueryF s s' f f' g p)
@@ -317,6 +326,7 @@ queryChild (ChildF p q) = do
 adaptState :: forall s t m a. (Monad m) => (s -> t) -> (t -> s) -> CMS.StateT s m a -> CMS.StateT t m a
 adaptState st ts (CMS.StateT f) = CMS.StateT \state -> f (ts state) >>= \(Tuple a s) -> pure $ Tuple a (st s)
 
+-- | Transforms a `Component`'s types.
 transform :: forall s s' f f' g
            . (Functor g)
           => (s -> s')

--- a/src/Halogen/Component/Private.purs
+++ b/src/Halogen/Component/Private.purs
@@ -1,0 +1,22 @@
+module Halogen.Component.Private
+  ( PrivateState()
+  , PrivateQuery()
+  , mkPrivate
+  ) where
+
+import Prelude
+import Data.Functor.Coproduct (Coproduct())
+import Unsafe.Coerce (unsafeCoerce)
+import Halogen
+
+data PrivateState
+data PrivateQuery a
+
+mkPrivate :: forall s s' f f' g p
+           . Component (s s') (Coproduct f f') g
+          -> p
+          -> s s'
+          -> SlotConstructor (s PrivateState) (Coproduct f PrivateQuery) g p
+mkPrivate c p is =
+  slotConstructor p \_ ->
+    unsafeCoerce { component: c, initialState: is }

--- a/src/Halogen/HTML.purs
+++ b/src/Halogen/HTML.purs
@@ -13,7 +13,7 @@ import Prelude ((<<<), Unit(), unit, Functor, (<$>))
 
 import Data.Bifunctor (bimap)
 
-import Halogen.Component (Component(), SlotConstructor(..), transformChild)
+import Halogen.Component (Component(), SlotConstructor(), slotConstructor, transformChild)
 import Halogen.Component.ChildPath (ChildPath(), injSlot, injState)
 import Halogen.HTML.Core
 import Halogen.HTML.Elements
@@ -28,7 +28,7 @@ slot :: forall s f g p i
       . p
      -> (Unit -> { component :: Component s f g, initialState :: s })
      -> HTML (SlotConstructor s f g p) i
-slot p l = Slot (SlotConstructor p l)
+slot p l = Slot (slotConstructor p l)
 
 -- | Defines a slot for a child component when a parent has multiple types of
 -- | child component. Takes the `ChildPath` for the child component's type, a
@@ -39,7 +39,7 @@ slot' :: forall s s' f f' g p p' i
       -> p
       -> (Unit -> { component :: Component s f g, initialState :: s })
       -> HTML (SlotConstructor s' f' g p') i
-slot' i p l = Slot (SlotConstructor (injSlot i p) (transform <$> l))
+slot' i p l = Slot (slotConstructor (injSlot i p) (transform <$> l))
   where
   transform def =
     { component: transformChild i def.component


### PR DESCRIPTION
- Exposes the `transform` function that allows mapping over a component's state and query algebra
- Hides the internal representation of `SlotConstructor`

This second change is to enable us to perform a trick to allow us to hide the state and query algebra of child components in certain conditions:

``` purescript
module PrivateComponent where

data PrivateState
data PrivateQuery a

type State a = { ... private: a ... }
data Query a = ...

mkPrivateComponent :: forall s f g
                    . Component (State s) (Coproduct Query f) g
                   -> s
                   -> SlotConstructor (State PrivateState) (Coproduct Query PrivateQuery) g
```

This is possible by using transform on the component to pack/unpack `PrivateState` and `PrivateQuery` values. The unpacking of these values is partial, but as long as we only export the types and not the data constructors for `PrivateState` and `PrivateQuery` this is safe as we can ensure that there is no way for these values to originate from anywhere other than within the component itself, therefore we know we have the right type inside `PrivateQuery`.

The change to hide `SlotConstructor`'s representation ensures that we can't make two `PrivateComponent`s with different internal state values and then extract their `initialState` values and swap them over or something. Basically ensuring we keep the guarantee that there is no place a `PrivateState` value is accessible except during the transformation of the private component.

@jonsterling I decided tweaking Halogen probably was worth it to achieve this - it seems likely we might want to do this existential children trick in other places too, and since this doesn't involve breaking `H.slot`'s interface or introducing yet another variant we _almost_ had the means to it already anyway (`H.slot` creates a `SlotConstructor`, so we'll just bypass that when making a parent component for children using this trick and use `HTML`'s `Slot` constructor directly).