### PR TITLE
Add style to global attrs, add autocomplete property

### DIFF
--- a/docs/Halogen/HTML/Properties.md
+++ b/docs/Halogen/HTML/Properties.md
@@ -180,6 +180,12 @@ selected :: forall i. Boolean -> Prop i
 placeholder :: forall i. String -> Prop i
 ```
 
+#### `autocomplete`
+
+``` purescript
+autocomplete :: forall i. Boolean -> Prop i
+```
+
 #### `initializer`
 
 ``` purescript

--- a/docs/Halogen/HTML/Properties/Indexed.md
+++ b/docs/Halogen/HTML/Properties/Indexed.md
@@ -8,6 +8,7 @@ unrefined versions.
 
 ``` purescript
 newtype IProp (r :: # *) i
+  = IProp (Prop i)
 ```
 
 The phantom row `r` can be thought of as a context which is synthesized in the
@@ -314,7 +315,7 @@ finalizer :: forall r i. (HTMLElement -> i) -> IProp (finalizer :: I | r) i
 #### `GlobalAttributes`
 
 ``` purescript
-type GlobalAttributes r = (id :: I, name :: I, title :: I, class :: I, spellcheck :: I, key :: I, initializer :: I, finalizer :: I | r)
+type GlobalAttributes r = (id :: I, name :: I, title :: I, class :: I, style :: I, spellcheck :: I, key :: I, initializer :: I, finalizer :: I | r)
 ```
 
 #### `GlobalEvents`

--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -27,6 +27,7 @@ module Halogen.HTML.Properties
   , checked
   , selected
   , placeholder
+  , autocomplete
   , initializer
   , finalizer
   , LengthLiteral(..)
@@ -136,6 +137,9 @@ selected = prop (propName "selected") (Just $ attrName "selected")
 
 placeholder :: forall i. String -> Prop i
 placeholder = prop (propName "placeholder") (Just $ attrName "placeholder")
+
+autocomplete :: forall i. Boolean -> Prop i
+autocomplete = prop (propName "autocomplete") (Just $ attrName "autocomplete") <<< (\b -> if b then "on" else "off")
 
 initializer :: forall i. (HTMLElement -> i) -> Prop i
 initializer = Initializer

--- a/src/Halogen/HTML/Properties/Indexed.purs
+++ b/src/Halogen/HTML/Properties/Indexed.purs
@@ -2,7 +2,7 @@
 -- | used to ensure correctness by construction, and then erased into the standard
 -- | unrefined versions.
 module Halogen.HTML.Properties.Indexed
-  ( IProp()
+  ( IProp(..)
   , I()
 
   , ButtonType(..)
@@ -312,6 +312,9 @@ selected = unsafeCoerce P.selected
 placeholder :: forall r i. String -> IProp (placeholder :: I | r) i
 placeholder = unsafeCoerce P.placeholder
 
+autocomplete :: forall r i. Boolean -> IProp (autocomplete :: I | r) i
+autocomplete = unsafeCoerce P.autocomplete
+
 initializer :: forall r i. (HTMLElement -> i) -> IProp (initializer :: I | r) i
 initializer = unsafeCoerce P.initializer
 
@@ -323,6 +326,7 @@ type GlobalAttributes r =
   , name :: I
   , title :: I
   , class :: I
+  , style :: I
   , spellcheck :: I
   , key :: I
   , initializer :: I


### PR DESCRIPTION
Resolves #190 and makes it possible to use the `style` attribute! There's a corresponding PR in `purescript-halogen-css`.