### PR TITLE
Update docs and examples

### DIFF
--- a/examples/ace/src/AceComponent.purs
+++ b/examples/ace/src/AceComponent.purs
@@ -44,13 +44,13 @@ ace = component render eval
 
   -- As we're embedding a 3rd party component we only need to create a
   -- placeholder div here and attach the initializer property.
-  render :: Render AceState AceQuery
+  render :: AceState -> ComponentHTML AceQuery
   render = const $ H.div [ P.initializer \el -> action (Init el) ] []
 
   -- The query algebra for the component handles the initialization of the Ace
   -- editor as well as responding to the `ChangeText` action that allows us to
   -- alter the editor's state.
-  eval :: Eval AceQuery AceState AceQuery (Aff (AceEffects eff))
+  eval :: Natural AceQuery (ComponentDSL AceState AceQuery (Aff (AceEffects eff)))
   eval (Init el next) = do
     editor <- liftEff' $ Ace.editNode el Ace.ace
     modify _ { editor = Just editor }

--- a/examples/components/src/Ticker.purs
+++ b/examples/components/src/Ticker.purs
@@ -17,14 +17,20 @@ ticker :: forall g. (Functor g) => Component TickState TickQuery g
 ticker = component render eval
   where
 
-  render :: Render TickState TickQuery
+  render :: TickState -> ComponentHTML TickQuery
   render (TickState n) =
-    H.div_ [ H.h1 [ P.id_ "header" ] [ H.text "counter" ]
-           , H.p_ [ H.text (show n) ]
-           , H.button [ E.onClick (E.input_ Tick) ] [ H.text "Tick" ]
-           ]
+    H.div_
+      [ H.h1
+          [ P.id_ "header" ]
+          [ H.text "counter" ]
+      , H.p_
+          [ H.text (show n) ]
+      , H.button
+          [ E.onClick (E.input_ Tick) ]
+          [ H.text "Tick" ]
+      ]
 
-  eval :: Eval TickQuery TickState TickQuery g
+  eval :: Natural TickQuery (ComponentDSL TickState TickQuery g)
   eval (Tick next) = do
     modify (\(TickState n) -> TickState (n + 1))
     pure next

--- a/examples/counter/src/Counter.purs
+++ b/examples/counter/src/Counter.purs
@@ -22,13 +22,17 @@ ui :: forall g. (Functor g) => Component State Query g
 ui = component render eval
   where
 
-  render :: Render State Query
+  render :: State -> ComponentHTML Query
   render (State n) =
-    H.div_ [ H.h1 [ P.id_ "header" ] [ H.text "counter" ]
-           , H.p_ [ H.text (show n) ]
-           ]
+    H.div_
+      [ H.h1
+          [ P.id_ "header" ]
+          [ H.text "counter" ]
+      , H.p_
+          [ H.text (show n) ]
+      ]
 
-  eval :: Eval Query State Query g
+  eval :: Natural Query (ComponentDSL State Query g)
   eval (Tick next) = do
     modify (\(State n) -> State (n + 1))
     pure next

--- a/examples/interpret/src/Main.purs
+++ b/examples/interpret/src/Main.purs
@@ -3,12 +3,11 @@ module Example.Intro where
 import Prelude
 
 import Control.Monad.Aff (Aff(), runAff)
+import Control.Monad.Aff.Console (log)
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Console (CONSOLE())
 import Control.Monad.Eff.Exception (throwException)
 import Control.Monad.Free (Free(), liftF, foldFree)
-
-import Data.NaturalTransformation (Natural())
 
 import Halogen
 import Halogen.Util (appendToBody)
@@ -32,14 +31,17 @@ ui :: Component State Query Output
 ui = component render eval
   where
 
-  render :: Render State Query
-  render state = H.div_
-    [ H.h1_ [ H.text "Toggle Button" ]
-    , H.button [ E.onClick (E.input_ ToggleState) ]
-               [ H.text (if state.on then "On" else "Off") ]
-    ]
+  render :: State -> ComponentHTML Query
+  render state =
+    H.div_
+      [ H.h1_
+          [ H.text "Toggle Button" ]
+      , H.button
+          [ E.onClick (E.input_ ToggleState) ]
+          [ H.text (if state.on then "On" else "Off") ]
+      ]
 
-  eval :: Eval Query State Query Output
+  eval :: Natural Query (ComponentDSL State Query Output)
   eval (ToggleState next) = do
     modify (\state -> { on: not state.on })
     liftH $ output "State was toggled"
@@ -50,7 +52,7 @@ ui' = interpret (foldFree evalOutput) ui
   where
   evalOutput :: Natural OutputF (Aff (HalogenEffects (console :: CONSOLE | eff)))
   evalOutput (Log msg next) = do
-    Control.Monad.Aff.Console.log msg
+    log msg
     pure next
 
 main :: Eff (HalogenEffects (console :: CONSOLE)) Unit

--- a/examples/intro/src/Main.purs
+++ b/examples/intro/src/Main.purs
@@ -22,14 +22,17 @@ ui :: forall g. (Functor g) => Component State Query g
 ui = component render eval
   where
 
-  render :: Render State Query
-  render state = H.div_
-    [ H.h1_ [ H.text "Toggle Button" ]
-    , H.button [ E.onClick (E.input_ ToggleState) ]
-               [ H.text (if state.on then "On" else "Off") ]
-    ]
+  render :: State -> ComponentHTML Query
+  render state =
+    H.div_
+      [ H.h1_
+          [ H.text "Toggle Button" ]
+      , H.button
+          [ E.onClick (E.input_ ToggleState) ]
+          [ H.text (if state.on then "On" else "Off") ]
+      ]
 
-  eval :: Eval Query State Query g
+  eval :: Natural Query (ComponentDSL State Query g)
   eval (ToggleState next) = do
     modify (\state -> { on: not state.on })
     pure next

--- a/examples/lifecycle/src/Main.purs
+++ b/examples/lifecycle/src/Main.purs
@@ -26,20 +26,27 @@ ui :: forall g. (Functor g) => Component State Query g
 ui = component render eval
   where
 
-  render :: Render State Query
-  render state = H.div_
-    [ H.h1_ [ H.text "Toggle Button" ]
-    , H.button [ E.onClick (E.input_ ToggleState) ]
-               [ H.text (if state.on then "Hide" else "Show") ]
-    , if state.on
-         then H.span [ P.initializer \_ -> action (AddEvent "Initialized")
-                     , P.finalizer \_ -> action (AddEvent "Finalized") ]
-                     [ H.text "Hello, World!" ]
-         else H.text ""
-    , H.ul_ (map (\event -> H.li_ [ H.text event ]) state.events)
-    ]
+  render :: State -> ComponentHTML Query
+  render state =
+    H.div_
+      [ H.h1_
+          [ H.text "Toggle Button" ]
+      , H.button
+          [ E.onClick (E.input_ ToggleState) ]
+          [ H.text (if state.on then "Hide" else "Show") ]
+      , if state.on
+        then
+          H.span
+            [ P.initializer \_ -> action (AddEvent "Initialized")
+            , P.finalizer \_ -> action (AddEvent "Finalized")
+            ]
+            [ H.text "Hello, World!" ]
+        else
+          H.text ""
+      , H.ul_ (map (\event -> H.li_ [ H.text event ]) state.events)
+      ]
 
-  eval :: Eval Query State Query g
+  eval :: Natural Query (ComponentDSL State Query g)
   eval (ToggleState next) = do
     modify (\state -> state { on = not state.on })
     pure next

--- a/examples/multi-component/src/ComponentA.purs
+++ b/examples/multi-component/src/ComponentA.purs
@@ -26,14 +26,14 @@ componentA :: forall g. (Functor g) => Component StateA QueryA g
 componentA = component render eval
   where
 
-  render :: Render StateA QueryA
+  render :: StateA -> ComponentHTML QueryA
   render (StateA state) = H.div_
     [ H.h1_ [ H.text "Toggle Button A" ]
     , H.button [ E.onClick (E.input_ ToggleStateA) ]
                [ H.text (if state.on then "On" else "Off") ]
     ]
 
-  eval :: Eval QueryA StateA QueryA g
+  eval :: Natural QueryA (ComponentDSL StateA QueryA g)
   eval (ToggleStateA next) = do
     modify (\(StateA state) -> StateA { on: not state.on })
     pure next

--- a/examples/multi-component/src/ComponentB.purs
+++ b/examples/multi-component/src/ComponentB.purs
@@ -26,14 +26,14 @@ componentB :: forall g. (Functor g) => Component StateB QueryB g
 componentB = component render eval
   where
 
-  render :: Render StateB QueryB
+  render :: StateB -> ComponentHTML QueryB
   render (StateB state) = H.div_
     [ H.h1_ [ H.text "Toggle Button B" ]
     , H.button [ E.onClick (E.input_ ToggleStateB) ]
                [ H.text (if state.on then "On" else "Off") ]
     ]
 
-  eval :: Eval QueryB StateB QueryB g
+  eval :: Natural QueryB (ComponentDSL StateB QueryB g)
   eval (ToggleStateB next) = do
     modify (\(StateB state) -> StateB { on: not state.on })
     pure next

--- a/examples/multi-component/src/ComponentC.purs
+++ b/examples/multi-component/src/ComponentC.purs
@@ -26,14 +26,14 @@ componentC :: forall g. (Functor g) => Component StateC QueryC g
 componentC = component render eval
   where
 
-  render :: Render StateC QueryC
+  render :: StateC -> ComponentHTML QueryC
   render (StateC state) = H.div_
     [ H.h1_ [ H.text "Toggle Button C" ]
     , H.button [ E.onClick (E.input_ ToggleStateC) ]
                [ H.text (if state.on then "On" else "Off") ]
     ]
 
-  eval :: Eval QueryC StateC QueryC g
+  eval :: Natural QueryC (ComponentDSL StateC QueryC g)
   eval (ToggleStateC next) = do
     modify (\(StateC state) -> StateC { on: not state.on })
     pure next

--- a/examples/multi-component/src/Main.purs
+++ b/examples/multi-component/src/Main.purs
@@ -45,11 +45,11 @@ cpC = cpR :> cpR
 type StateP g = InstalledState State ChildState Query ChildQuery g ChildSlot
 type QueryP = Coproduct Query (ChildF ChildSlot ChildQuery)
 
-ui :: forall g. (Plus g) => Component (StateP g) QueryP g
+ui :: forall g. (Functor g) => Component (StateP g) QueryP g
 ui = parentComponent' render eval (const (pure unit))
   where
 
-  render :: RenderParent State ChildState Query ChildQuery g ChildSlot
+  render :: State -> ParentHTML ChildState Query ChildQuery g ChildSlot
   render (State state) = H.div_
     [ H.div_ [ H.slot' cpA SlotA \_ -> { component: componentA, initialState: initStateA } ]
     , H.div_ [ H.slot' cpB SlotB \_ -> { component: componentB, initialState: initStateB } ]
@@ -58,7 +58,7 @@ ui = parentComponent' render eval (const (pure unit))
     , H.button [ E.onClick (E.input_ ReadStates) ] [ H.text "Read states" ]
     ]
 
-  eval :: EvalParent Query State ChildState Query ChildQuery g ChildSlot
+  eval :: Natural Query (ParentDSL State ChildState Query ChildQuery g ChildSlot)
   eval (ReadStates next) = do
     a <- query' cpA SlotA (request GetStateA)
     b <- query' cpB SlotB (request GetStateB)

--- a/examples/todo/src/Component/List.purs
+++ b/examples/todo/src/Component/List.purs
@@ -9,7 +9,6 @@ import Data.Array (snoc, filter, length)
 import Data.Functor.Coproduct (Coproduct())
 import Data.Generic (Generic, gEq, gCompare)
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.NaturalTransformation (Natural())
 
 import Halogen
 import qualified Halogen.HTML.Indexed as H
@@ -32,7 +31,7 @@ type State g = InstalledState List Task ListQuery TaskQuery g TaskSlot
 type Query = Coproduct ListQuery (ChildF TaskSlot TaskQuery)
 
 -- | The list component definition.
-list :: forall g. (Plus g) => Component (State g) Query g
+list :: forall g. (Functor g) => Component (State g) Query g
 list = parentComponent' render eval peek
   where
 

--- a/examples/todo/src/Component/Task.purs
+++ b/examples/todo/src/Component/Task.purs
@@ -2,8 +2,6 @@ module Component.Task where
 
 import Prelude
 
-import Data.NaturalTransformation (Natural())
-
 import Halogen
 import qualified Halogen.HTML.Indexed as H
 import qualified Halogen.HTML.Properties.Indexed as P

--- a/src/Halogen.purs
+++ b/src/Halogen.purs
@@ -9,9 +9,12 @@ module Halogen
   , module Halogen.Driver
   , module Halogen.Effects
   , module Halogen.Query
+  , module Data.NaturalTransformation
   ) where
 
 import Prelude
+
+import Data.NaturalTransformation (Natural())
 
 import Halogen.Component
 import Halogen.Driver


### PR DESCRIPTION
- Switched all the examples over to use the new type synonyms and jondentation
- Updated the docs to explain the new synonyms a bit
- Relaxed `Plus` constraints for `Functor` where possible now we can do that
- Tweak to the wording about HalogenF to remove mention of coproduct
- `Halogen` re-exports `Natural` as per @natefaubion's suggestion - I wasn't sure about this idea at first, but it is pretty useful and does no harm, it won't break anything that explicitly imports `Natural` alongside `Halogen`.