### PR TITLE
[Request for Comment] Swallow up bad queries

### DIFF
--- a/docs/Halogen/Component.md
+++ b/docs/Halogen/Component.md
@@ -131,7 +131,7 @@ descendant components have processed.
 #### `InstalledState`
 
 ``` purescript
-type InstalledState s s' f f' g p = { parent :: s, children :: Map p (Tuple (Component s' f' g) s'), memo :: Map p (HTML Void (Coproduct f (ChildF p f') Unit)) }
+newtype InstalledState s s' f f' g p
 ```
 
 The type used by component containers for their state where `s` is the
@@ -271,7 +271,7 @@ the generated `HTML` and new state.
 queryComponent :: forall s f g. Component s f g -> Eval f s f g
 ```
 
-Runs a compnent's `query` function with the specified query input and
+Runs a component's `query` function with the specified query input and
 returns the pending computation as a `Free` monad.
 
 


### PR DESCRIPTION
In #230, an operator was added that allowed a "partial" transformation of components, with the caveat that a user sending a bad query to a child component would be interpreted into `HaltHF` (a runtime error); in the PR thread, we discussed the possibility of changing this so that it would instead result in `Nothing` getting returned from `query`. This is an implementation of that idea (thanks to @garyb for your help!).

Now, I am not certain this is actually a good idea, which is why the PR is entitled "Request for Comment". My concern is that this may obscure the correctness conditions of a component and hide actual bugs in code (if you agree with me that a bug in a program should be fatal, rather than being "handled" in-program). However, one might argue that we have already made this design decision by having `query` return `Maybe` rather than have a fatal error in case the child component is not present, and so we should perhaps be consistent. What do people think?