### PR TITLE
[Request for comment] Try switching event streams to something that can terminate

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,7 @@
     "purescript-maps": "^0.5.0",
     "purescript-nullable": "^0.2.0",
     "purescript-profunctor": "^0.3.1",
+    "purescript-stalling-coroutines": "^0.1.0",
     "purescript-unsafe-coerce": "^0.1.0",
     "purescript-void": "^0.3.0"
   }

--- a/docs/Halogen/Component.md
+++ b/docs/Halogen/Component.md
@@ -131,7 +131,7 @@ descendant components have processed.
 #### `InstalledState`
 
 ``` purescript
-type InstalledState s s' f f' g p = { parent :: s, children :: Map p (Tuple (Component s' f' g) s'), memo :: Map p (HTML Void (Coproduct f (ChildF p f') Unit)) }
+newtype InstalledState s s' f f' g p
 ```
 
 The type used by component containers for their state where `s` is the

--- a/docs/Halogen/Query/SubscribeF.md
+++ b/docs/Halogen/Query/SubscribeF.md
@@ -6,7 +6,7 @@ listeners.
 #### `EventSource`
 
 ``` purescript
-type EventSource f g = Producer (f Unit) g Unit
+type EventSource f g = StallingProducer (f Unit) g Unit
 ```
 
 A type alias for a coroutine producer used to represent a subscribable

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp-jscs": "^1.6.0",
     "gulp-jshint": "^1.11.2",
     "gulp-purescript": "^0.7.0",
-    "purescript": "^0.7.4",
+    "purescript": "^0.7.5",
     "rimraf": "^2.4.1",
     "webpack-stream": "^2.0.0"
   },

--- a/src/Halogen/Query/SubscribeF.purs
+++ b/src/Halogen/Query/SubscribeF.purs
@@ -14,23 +14,28 @@ module Halogen.Query.SubscribeF
 import Prelude
 
 import Control.Bind ((<=<), (=<<))
-import Control.Coroutine (Producer(), Consumer(), runProcess, ($$))
+import Control.Coroutine as CR
+import Control.Coroutine.Stalling as SCR
 import Control.Coroutine.Aff (produce)
-import Control.Monad.Free.Trans (hoistFreeT, interpret)
+import Control.Monad.Free.Trans (hoistFreeT, interpret, runFreeT)
 import Control.Monad.Aff (Aff())
 import Control.Monad.Aff.AVar (AVAR())
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Class (MonadEff)
+import Control.Monad.Maybe.Trans
 import Control.Monad.Rec.Class (MonadRec)
+import Control.Plus (Plus, empty)
 
-import Data.Bifunctor (lmap)
+import Data.Identity
+import Data.Bifunctor (Bifunctor, lmap)
 import Data.Either (Either(..))
 import Data.Functor (($>))
+import Data.Maybe (Maybe(..), maybe)
 import Data.NaturalTransformation (Natural())
 
 -- | A type alias for a coroutine producer used to represent a subscribable
 -- | source of events.
-type EventSource f g = Producer (f Unit) g Unit
+type EventSource f g = SCR.StallingProducer (f Unit) g Unit
 
 -- | Creates an `EventSource` for an event listener that accepts one argument.
 -- |
@@ -49,7 +54,9 @@ eventSource
    . ((a -> Eff (avar :: AVAR | eff) Unit) -> Eff (avar :: AVAR | eff) Unit)
   -> (a -> Eff (avar :: AVAR | eff) (f Unit))
   -> EventSource f (Aff (avar :: AVAR | eff))
-eventSource attach handle = produce \emit -> attach (emit <<< Left <=< handle)
+eventSource attach handle =
+  SCR.producerToStallingProducer $ produce \emit ->
+    attach (emit <<< Left <=< handle)
 
 -- | Creates an `EventSource` for an event listener that accepts no arguments.
 -- |
@@ -69,7 +76,9 @@ eventSource_
    . (Eff (avar :: AVAR | eff) Unit -> Eff (avar :: AVAR | eff) Unit)
   -> Eff (avar :: AVAR | eff) (f Unit)
   -> EventSource f (Aff (avar :: AVAR | eff))
-eventSource_ attach handle = produce \emit -> attach (emit <<< Left =<< handle)
+eventSource_ attach handle =
+  SCR.producerToStallingProducer $ produce \emit ->
+    attach (emit <<< Left =<< handle)
 
 -- | The subscribe algebra.
 data SubscribeF f g a = Subscribe (EventSource f g) a
@@ -98,5 +107,5 @@ transformSubscribe eta theta (Subscribe p next) =
 
 -- | A natural transformation for interpreting the subscribe algebra as its
 -- | underlying monad, via a coroutine consumer. Used internally by Halogen.
-subscribeN :: forall f g. (MonadRec g) => Consumer (f Unit) g Unit -> Natural (SubscribeF f g) g
-subscribeN c (Subscribe p next) = runProcess (p $$ c) $> next
+subscribeN :: forall f g. (MonadRec g) => CR.Consumer (f Unit) g Unit -> Natural (SubscribeF f g) g
+subscribeN c (Subscribe p next) = SCR.runStallingProcess (p SCR.$$? c) $> next


### PR DESCRIPTION
@garyb 

This is a little experiment with switching `EventSource` from `Producer` to something that can terminate. The types seem to work; does it look like it does what we intend?

If we think that this is a viable path forward for #233, I can switch it to `ListT`, which should be equivalent, if people want. (Though the `FreeT` version seems so much cleaner & more composable.)