### PR TITLE
Switch EventSource to use purescript-stalling-coroutines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ script:
   - npm run example-intro
   - npm run example-multi-component
   - npm run example-todo
+  - npm run example-keyboard-shortcuts

--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,7 @@
     "purescript-maps": "^0.5.0",
     "purescript-nullable": "^0.2.0",
     "purescript-profunctor": "^0.3.1",
+    "purescript-stalling-coroutines": "^0.1.0",
     "purescript-unsafe-coerce": "^0.1.0",
     "purescript-void": "^0.3.0"
   }

--- a/docs/Halogen/Component.md
+++ b/docs/Halogen/Component.md
@@ -131,7 +131,7 @@ descendant components have processed.
 #### `InstalledState`
 
 ``` purescript
-type InstalledState s s' f f' g p = { parent :: s, children :: Map p (Tuple (Component s' f' g) s'), memo :: Map p (HTML Void (Coproduct f (ChildF p f') Unit)) }
+newtype InstalledState s s' f f' g p
 ```
 
 The type used by component containers for their state where `s` is the

--- a/docs/Halogen/Query/SubscribeF.md
+++ b/docs/Halogen/Query/SubscribeF.md
@@ -6,7 +6,7 @@ listeners.
 #### `EventSource`
 
 ``` purescript
-type EventSource f g = Producer (f Unit) g Unit
+type EventSource f g = StallingProducer (f Unit) g Unit
 ```
 
 A type alias for a coroutine producer used to represent a subscribable

--- a/examples/keyboard-shortcuts/.gitignore
+++ b/examples/keyboard-shortcuts/.gitignore
@@ -1,0 +1,3 @@
+/dist/example.js
+/output
+/bower_components

--- a/examples/keyboard-shortcuts/README.md
+++ b/examples/keyboard-shortcuts/README.md
@@ -1,0 +1,15 @@
+## Keyboard Shortcuts example
+
+This example illustrates how to selectively capture keyboard events.
+
+### Building
+
+From the root of the Halogen project:
+
+```
+$ npm run example-keyboard-shortcuts
+```
+
+The code will be built as `example.js` in the
+`examples/keyboard-shortcuts/dist` directory within the example, runnable by
+opening the corresponding `index.html`.

--- a/examples/keyboard-shortcuts/bower.json
+++ b/examples/keyboard-shortcuts/bower.json
@@ -1,0 +1,7 @@
+{
+  "name": "keyboard-shortcuts",
+  "private": true,
+  "dependencies": {
+    "purescript-halogen": "*"
+  }
+}

--- a/examples/keyboard-shortcuts/gulpfile.js
+++ b/examples/keyboard-shortcuts/gulpfile.js
@@ -1,0 +1,41 @@
+/* jshint node: true */
+"use strict";
+
+var gulp = require("gulp");
+var purescript = require("gulp-purescript");
+var webpack = require("webpack-stream");
+
+var sources = [
+  "src/**/*.purs",
+  "bower_components/purescript-*/src/**/*.purs"
+];
+
+var foreigns = [
+  "src/**/*.js",
+  "bower_components/purescript-*/src/**/*.js"
+];
+
+gulp.task("make", function() {
+  return purescript.psc({ src: sources, ffi: foreigns });
+});
+
+gulp.task("prebundle", ["make"], function() {
+  return purescript.pscBundle({
+    src: "output/**/*.js",
+    output: "dist/example.js",
+    module: "Example.Main",
+    main: "Example.Main"
+  });
+});
+
+gulp.task("bundle", ["prebundle"], function () {
+  return gulp.src("dist/example.js")
+    .pipe(webpack({
+      resolve: { modulesDirectories: ["node_modules"] },
+      output: { filename: "example.js" }
+    }))
+    .pipe(gulp.dest("dist"));
+});
+
+gulp.task("default", ["bundle"]);
+

--- a/examples/keyboard-shortcuts/src/Keyboard.js
+++ b/examples/keyboard-shortcuts/src/Keyboard.js
@@ -1,0 +1,21 @@
+/* global exports */
+"use strict";
+
+// module Keyboard
+exports.addEventListenerImpl = function(eventName, fn, element) {
+    return function() {
+        element.addEventListener(eventName, function(e) {
+            fn(e)();
+        });
+    };
+};
+
+exports.readKeyboardEvent = function(e) {
+    return e;
+};
+
+exports.preventDefault = function(e) {
+    return function() {
+        e.preventDefault();
+    };
+};

--- a/examples/keyboard-shortcuts/src/Keyboard.purs
+++ b/examples/keyboard-shortcuts/src/Keyboard.purs
@@ -1,0 +1,41 @@
+module Keyboard
+  ( KEYBOARD()
+  , KeyboardEvent()
+  , KeyboardEventR()
+  , readKeyboardEvent
+  , preventDefault
+  , onKeyUp
+  ) where
+
+import Prelude
+import Control.Monad.Eff
+import Data.Function as F
+
+import DOM (DOM())
+import DOM.Node.Types as DOM
+import DOM.HTML as DOM
+import DOM.HTML.Window as DOM
+import DOM.HTML.Types as DOM
+
+foreign import data KEYBOARD :: !
+foreign import addEventListenerImpl :: forall ev eff a. F.Fn3 String (ev -> Eff (keyboard :: KEYBOARD | eff) a) DOM.Document (Eff (keyboard :: KEYBOARD | eff) Unit)
+
+type KeyboardEventR =
+  { keyCode :: Int
+  , ctrlKey :: Boolean
+  , altKey :: Boolean
+  , metaKey :: Boolean
+  , shiftKey :: Boolean
+  }
+
+foreign import data KeyboardEvent :: *
+foreign import readKeyboardEvent :: KeyboardEvent -> KeyboardEventR
+foreign import preventDefault :: forall eff. KeyboardEvent -> Eff (keyboard :: KEYBOARD | eff) Unit
+
+onKeyUp
+  :: forall eff
+   . DOM.Document
+  -> (KeyboardEvent -> Eff (keyboard :: KEYBOARD | eff) Unit)
+  -> Eff (keyboard :: KEYBOARD | eff) Unit
+onKeyUp document fn =
+  F.runFn3 addEventListenerImpl "keyup" fn document

--- a/examples/keyboard-shortcuts/src/Main.purs
+++ b/examples/keyboard-shortcuts/src/Main.purs
@@ -1,0 +1,103 @@
+module Example.Main where
+
+import Prelude
+
+import Control.Coroutine as CR
+import Control.Coroutine.Stalling as SCR
+
+import Control.Monad.Aff as A
+import Control.Monad.Aff.AVar as A
+import Control.Monad.Aff (runAff)
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Exception (throwException)
+import Control.Monad.Rec.Class as MR
+import Control.Plus as P
+
+import Data.Const
+import Data.Functor.Coproduct
+import Data.Functor (($>))
+import Data.String as S
+import Data.Char as CH
+import Data.Maybe as M
+
+import DOM as DOM
+import DOM.Node.Types as DOM
+import DOM.HTML as DOM
+import DOM.HTML.Window as DOM
+import DOM.HTML.Types as DOM
+
+import Halogen
+import Halogen.Util (appendToBody)
+import Halogen.Query.SubscribeF as H
+import Halogen.HTML.Indexed as H
+import Halogen.HTML.Properties.Indexed as P
+import Halogen.HTML.Events.Indexed as E
+
+import Keyboard as K
+
+-- | The state of the application
+type State = { chars :: String }
+
+initialState :: State
+initialState = { chars : "" }
+
+-- | Queries to the state machine
+data Query a
+  = Init a
+  | AppendChar Char a
+  | Clear a
+
+-- | Effects embedding the Ace editor requires.
+type E eff = (dom :: DOM.DOM, avar :: A.AVAR, keyboard :: K.KEYBOARD | eff)
+
+ui :: forall eff. Component State Query (A.Aff (E eff))
+ui = component render eval
+  where
+    render :: State -> ComponentHTML Query
+    render state =
+      H.div
+        [ P.initializer \_ -> action Init
+        ]
+        [ H.p_ [ H.text "Hold down the shift key and type some characters!" ]
+        , H.p_ [ H.text state.chars ]
+        ]
+
+    eval :: Natural Query (ComponentDSL State Query (A.Aff (E eff)))
+    eval q =
+      case q of
+        Init next -> do
+          document <- liftEff' $ DOM.window >>= DOM.document <#> DOM.htmlDocumentToDocument
+          let
+            querySource :: EventSource (Coproduct (Const Unit) Query) (A.Aff (E eff))
+            querySource =
+              eventSource (K.onKeyUp document) \e -> do
+                let info = K.readKeyboardEvent e
+                if info.shiftKey
+                   then do
+                     K.preventDefault e
+                     let c = CH.fromCharCode info.keyCode
+                     pure $ action (right <<< AppendChar c)
+                   else if info.keyCode == 13 then do
+                     K.preventDefault e
+                     pure $ action (right <<< Clear)
+                   else do
+                     pure $ left (Const unit)
+
+          subscribe $ H.catEventSource querySource
+          pure next
+        AppendChar c next -> do
+          modify (\st -> st { chars = st.chars <> CH.toString c })
+          pure next
+        Clear next -> do
+          modify (_ { chars = "" })
+          pure next
+
+main :: Eff (HalogenEffects (keyboard :: K.KEYBOARD)) Unit
+main =
+  runAff throwException (const (pure unit)) do
+    app <- runUI ui initialState
+    appendToBody app.node
+
+
+hole :: forall a. a
+hole = Unsafe.Coerce.unsafeCoerce ""

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "example-intro": "bower link && cd examples/intro && bower link purescript-halogen && gulp",
     "example-lifecycle": "bower link && cd examples/lifecycle && bower link purescript-halogen && gulp",
     "example-multi-component": "bower link && cd examples/multi-component && bower link purescript-halogen && gulp",
-    "example-todo": "bower link && cd examples/todo && bower link purescript-halogen && gulp"
+    "example-todo": "bower link && cd examples/todo && bower link purescript-halogen && gulp",
+    "example-keyboard-shortcuts": "bower link && cd examples/keyboard-shortcuts && bower link purescript-halogen && gulp"
   },
   "devDependencies": {
     "bower": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp-jscs": "^1.6.0",
     "gulp-jshint": "^1.11.2",
     "gulp-purescript": "^0.7.0",
-    "purescript": "^0.7.4",
+    "purescript": "^0.7.5",
     "rimraf": "^2.4.1",
     "webpack-stream": "^2.0.0"
   },

--- a/src/Halogen/Query/SubscribeF.purs
+++ b/src/Halogen/Query/SubscribeF.purs
@@ -14,23 +14,28 @@ module Halogen.Query.SubscribeF
 import Prelude
 
 import Control.Bind ((<=<), (=<<))
-import Control.Coroutine (Producer(), Consumer(), runProcess, ($$))
+import Control.Coroutine as CR
+import Control.Coroutine.Stalling as SCR
 import Control.Coroutine.Aff (produce)
-import Control.Monad.Free.Trans (hoistFreeT, interpret)
+import Control.Monad.Free.Trans (hoistFreeT, interpret, runFreeT)
 import Control.Monad.Aff (Aff())
 import Control.Monad.Aff.AVar (AVAR())
 import Control.Monad.Eff (Eff())
 import Control.Monad.Eff.Class (MonadEff)
+import Control.Monad.Maybe.Trans
 import Control.Monad.Rec.Class (MonadRec)
+import Control.Plus (Plus, empty)
 
-import Data.Bifunctor (lmap)
+import Data.Identity
+import Data.Bifunctor (Bifunctor, lmap)
 import Data.Either (Either(..))
 import Data.Functor (($>))
+import Data.Maybe (Maybe(..), maybe)
 import Data.NaturalTransformation (Natural())
 
 -- | A type alias for a coroutine producer used to represent a subscribable
 -- | source of events.
-type EventSource f g = Producer (f Unit) g Unit
+type EventSource f g = SCR.StallingProducer (f Unit) g Unit
 
 -- | Creates an `EventSource` for an event listener that accepts one argument.
 -- |
@@ -49,7 +54,9 @@ eventSource
    . ((a -> Eff (avar :: AVAR | eff) Unit) -> Eff (avar :: AVAR | eff) Unit)
   -> (a -> Eff (avar :: AVAR | eff) (f Unit))
   -> EventSource f (Aff (avar :: AVAR | eff))
-eventSource attach handle = produce \emit -> attach (emit <<< Left <=< handle)
+eventSource attach handle =
+  SCR.producerToStallingProducer $ produce \emit ->
+    attach (emit <<< Left <=< handle)
 
 -- | Creates an `EventSource` for an event listener that accepts no arguments.
 -- |
@@ -69,7 +76,9 @@ eventSource_
    . (Eff (avar :: AVAR | eff) Unit -> Eff (avar :: AVAR | eff) Unit)
   -> Eff (avar :: AVAR | eff) (f Unit)
   -> EventSource f (Aff (avar :: AVAR | eff))
-eventSource_ attach handle = produce \emit -> attach (emit <<< Left =<< handle)
+eventSource_ attach handle =
+  SCR.producerToStallingProducer $ produce \emit ->
+    attach (emit <<< Left =<< handle)
 
 -- | The subscribe algebra.
 data SubscribeF f g a = Subscribe (EventSource f g) a
@@ -98,5 +107,5 @@ transformSubscribe eta theta (Subscribe p next) =
 
 -- | A natural transformation for interpreting the subscribe algebra as its
 -- | underlying monad, via a coroutine consumer. Used internally by Halogen.
-subscribeN :: forall f g. (MonadRec g) => Consumer (f Unit) g Unit -> Natural (SubscribeF f g) g
-subscribeN c (Subscribe p next) = runProcess (p $$ c) $> next
+subscribeN :: forall f g. (MonadRec g) => CR.Consumer (f Unit) g Unit -> Natural (SubscribeF f g) g
+subscribeN c (Subscribe p next) = SCR.runStallingProcess (p SCR.$$? c) $> next


### PR DESCRIPTION
This will allow users to filter event sources (see [`Control.Coroutine.Stalling.filter`](https://github.com/slamdata/purescript-stalling-coroutines/blob/master/docs/Control/Coroutine/Stalling.md#filter)). This is meant to resolve #233.