### PR TITLE
Add subscribe' for parent components

### DIFF
--- a/docs/Halogen/Query.md
+++ b/docs/Halogen/Query.md
@@ -166,7 +166,16 @@ subscribe :: forall s f g. EventSource f g -> Free (HalogenF s f g) Unit
 ```
 
 Provides a way of having a component subscribe to an `EventSource` from
-within an `Eval` or `Peek` function.
+within an `Eval` function.
+
+#### `subscribe'`
+
+``` purescript
+subscribe' :: forall s s' f f' g. EventSource f g -> Free (HalogenF s f (Free (HalogenF s' f' g))) Unit
+```
+
+Provides a way of having a parent component subscribe to an `EventSource`
+from within an `Eval` or `Peek` function.
 
 #### `liftH`
 

--- a/docs/Halogen/Query/SubscribeF.md
+++ b/docs/Halogen/Query/SubscribeF.md
@@ -51,6 +51,15 @@ let onChange = eventSource_ (Session.onChange session) do
 ```
 (Taken from the Ace component example)
 
+#### `catEventSource`
+
+``` purescript
+catEventSource :: forall f g. (MonadRec g) => EventSource (Coproduct (Const Unit) f) g -> EventSource f g
+```
+
+Take an `EventSource` with events in `1 + f` to one with events in `f`.
+This is useful for simultaneously filtering and handling events.
+
 #### `SubscribeF`
 
 ``` purescript


### PR DESCRIPTION
@jonsterling !!! 

You already discovered the magic invocation we needed to make all this stuff work without changing anything about `SubscribeF` :heart_eyes: 

We just need to `hoistFreeT liftH` an `EventSource` to make it compatible, you did this in the `FileInput` and it suddenly clicked that that's all we needed here too.

Resolves #242, resolves #234