### PR TITLE
Add autofocus property

### DIFF
--- a/docs/Halogen/HTML/Properties.md
+++ b/docs/Halogen/HTML/Properties.md
@@ -186,6 +186,12 @@ placeholder :: forall i. String -> Prop i
 autocomplete :: forall i. Boolean -> Prop i
 ```
 
+#### `autofocus`
+
+``` purescript
+autofocus :: forall i. Boolean -> Prop i
+```
+
 #### `initializer`
 
 ``` purescript

--- a/docs/Halogen/HTML/Properties/Indexed.md
+++ b/docs/Halogen/HTML/Properties/Indexed.md
@@ -300,6 +300,18 @@ selected :: forall r i. Boolean -> IProp (selected :: I | r) i
 placeholder :: forall r i. String -> IProp (placeholder :: I | r) i
 ```
 
+#### `autocomplete`
+
+``` purescript
+autocomplete :: forall r i. Boolean -> IProp (autocomplete :: I | r) i
+```
+
+#### `autofocus`
+
+``` purescript
+autofocus :: forall r i. Boolean -> IProp (autofocus :: I | r) i
+```
+
 #### `initializer`
 
 ``` purescript

--- a/docs/Halogen/Query/SubscribeF.md
+++ b/docs/Halogen/Query/SubscribeF.md
@@ -51,6 +51,15 @@ let onChange = eventSource_ (Session.onChange session) do
 ```
 (Taken from the Ace component example)
 
+#### `catEventSource`
+
+``` purescript
+catEventSource :: forall f g. (MonadRec g) => EventSource (Coproduct (Const Unit) f) g -> EventSource f g
+```
+
+Take an `EventSource` with events in `1 + f` to one with events in `f`.
+This is useful for simultaneously filtering and handling events.
+
 #### `SubscribeF`
 
 ``` purescript

--- a/examples/todo/src/Component/Task.purs
+++ b/examples/todo/src/Component/Task.purs
@@ -30,6 +30,7 @@ task = component render eval
                     ]
           , H.input [ P.inputType P.InputText
                     , P.placeholder "Task description"
+                    , P.autofocus true
                     , P.value t.description
                     , E.onValueChange (E.input UpdateDescription)
                     ]

--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -28,6 +28,7 @@ module Halogen.HTML.Properties
   , selected
   , placeholder
   , autocomplete
+  , autofocus
   , initializer
   , finalizer
   , LengthLiteral(..)
@@ -138,6 +139,9 @@ placeholder = prop (propName "placeholder") (Just $ attrName "placeholder")
 
 autocomplete :: forall i. Boolean -> Prop i
 autocomplete = prop (propName "autocomplete") (Just $ attrName "autocomplete") <<< (\b -> if b then "on" else "off")
+
+autofocus :: forall i. Boolean -> Prop i
+autofocus = prop (propName "autofocus") (Just $ attrName "autofocus")
 
 initializer :: forall i. (HTMLElement -> i) -> Prop i
 initializer = Initializer

--- a/src/Halogen/HTML/Properties/Indexed.purs
+++ b/src/Halogen/HTML/Properties/Indexed.purs
@@ -48,7 +48,9 @@ module Halogen.HTML.Properties.Indexed
   , checked
   , selected
   , placeholder
-
+  , autocomplete
+  , autofocus
+  
   , initializer
   , finalizer
 
@@ -314,6 +316,9 @@ placeholder = unsafeCoerce P.placeholder
 
 autocomplete :: forall r i. Boolean -> IProp (autocomplete :: I | r) i
 autocomplete = unsafeCoerce P.autocomplete
+
+autofocus :: forall r i. Boolean -> IProp (autofocus :: I | r) i
+autofocus = unsafeCoerce P.autofocus
 
 initializer :: forall r i. (HTMLElement -> i) -> IProp (initializer :: I | r) i
 initializer = unsafeCoerce P.initializer


### PR DESCRIPTION
Autofocus was already listed as a valid property on the `input` element function, but it was not yet defined in Halogen.HTML.Properties or Halogen.HTML.Properties.Indexed.

This PR adds the `autofocus` property definitions and adds the new property to the example `example-todo`.

Note: I'm not sure how valid the `autofocus` property is on a completely client-side rendered app, since the browser only seems to read it on initial page load.  It's still part of the spec, though, and there could be a future case like server-rendered html.