### PR TITLE
update purescript-generics dependencies in examples to version 0.7.0+

### DIFF
--- a/examples/ace/bower.json
+++ b/examples/ace/bower.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "purescript-ace": "^0.8.0",
-    "purescript-generics": "^0.6.1",
+    "purescript-generics": "^0.7.0",
     "purescript-halogen": "*"
   }
 }

--- a/examples/components/bower.json
+++ b/examples/components/bower.json
@@ -2,7 +2,7 @@
   "name": "components",
   "private": true,
   "dependencies": {
-    "purescript-generics": "^0.6.1",
+    "purescript-generics": "^0.7.0",
     "purescript-halogen": "*"
   }
 }

--- a/examples/deep-peek/bower.json
+++ b/examples/deep-peek/bower.json
@@ -2,7 +2,7 @@
   "name": "deep-peek",
   "private": true,
   "dependencies": {
-    "purescript-generics": "^0.6.2",
+    "purescript-generics": "^0.7.0",
     "purescript-halogen": "*"
   }
 }

--- a/examples/multi-component/bower.json
+++ b/examples/multi-component/bower.json
@@ -2,7 +2,7 @@
   "name": "multi-component",
   "private": true,
   "dependencies": {
-    "purescript-generics": "^0.6.1",
+    "purescript-generics": "^0.7.0",
     "purescript-halogen": "*"
   }
 }

--- a/examples/todo/bower.json
+++ b/examples/todo/bower.json
@@ -2,7 +2,7 @@
   "name": "todo",
   "private": true,
   "dependencies": {
-    "purescript-generics": "^0.6.1",
+    "purescript-generics": "^0.7.0",
     "purescript-halogen": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,17 +10,17 @@
   "scripts": {
     "postinstall": "bower install",
     "build": "gulp",
-    "example-ace": "bower link && cd examples/ace && bower link purescript-halogen && gulp",
-    "example-ajax": "bower link && cd examples/ajax && bower link purescript-halogen && gulp",
-    "example-components": "bower link && cd examples/components && bower link purescript-halogen && gulp",
-    "example-counter": "bower link && cd examples/counter && bower link purescript-halogen && gulp",
-    "example-deep-peek": "bower link && cd examples/deep-peek && bower link purescript-halogen && gulp",
-    "example-interpret": "bower link && cd examples/interpret && bower link purescript-halogen && gulp",
-    "example-intro": "bower link && cd examples/intro && bower link purescript-halogen && gulp",
-    "example-lifecycle": "bower link && cd examples/lifecycle && bower link purescript-halogen && gulp",
-    "example-multi-component": "bower link && cd examples/multi-component && bower link purescript-halogen && gulp",
-    "example-todo": "bower link && cd examples/todo && bower link purescript-halogen && gulp",
-    "example-keyboard-shortcuts": "bower link && cd examples/keyboard-shortcuts && bower link purescript-halogen && gulp"
+    "example-ace": "bower link && cd examples/ace && bower link purescript-halogen && bower install && gulp",
+    "example-ajax": "bower link && cd examples/ajax && bower link purescript-halogen && bower install && gulp",
+    "example-components": "bower link && cd examples/components && bower link purescript-halogen && bower install && gulp",
+    "example-counter": "bower link && cd examples/counter && bower link purescript-halogen && bower install && gulp",
+    "example-deep-peek": "bower link && cd examples/deep-peek && bower link purescript-halogen && bower install && gulp",
+    "example-interpret": "bower link && cd examples/interpret && bower link purescript-halogen && bower install && gulp",
+    "example-intro": "bower link && cd examples/intro && bower link purescript-halogen && bower install && gulp",
+    "example-lifecycle": "bower link && cd examples/lifecycle && bower link purescript-halogen && bower install && gulp",
+    "example-multi-component": "bower link && cd examples/multi-component && bower link purescript-halogen && bower install && gulp",
+    "example-todo": "bower link && cd examples/todo && bower link purescript-halogen && bower install && gulp",
+    "example-keyboard-shortcuts": "bower link && cd examples/keyboard-shortcuts && bower link purescript-halogen && bower install && gulp"
   },
   "devDependencies": {
     "bower": "^1.4.1",
@@ -28,7 +28,7 @@
     "gulp-jscs": "^1.6.0",
     "gulp-jshint": "^1.11.2",
     "gulp-purescript": "^0.7.0",
-    "purescript": "^0.7.5",
+    "purescript": "^0.7.6",
     "rimraf": "^2.4.1",
     "webpack-stream": "^2.0.0"
   },


### PR DESCRIPTION
fixes compilation errors with psc 0.7.6.1