### PR TITLE
Add `rows` and `cols` to (Indexed) Properties.

### DIFF
--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -5,6 +5,8 @@ module Halogen.HTML.Properties
   , charset
   , class_
   , classes
+  , cols
+  , rows
   , colSpan
   , rowSpan
   , for
@@ -67,6 +69,12 @@ class_ = prop (propName "className") (Just $ attrName "class") <<< runClassName
 
 classes :: forall i. Array ClassName -> Prop i
 classes = prop (propName "className") (Just $ attrName "class") <<< joinWith " " <<< map runClassName
+
+cols :: forall i. Int -> Prop i
+cols = prop (propName "cols") (Just $ attrName "cols")
+
+rows :: forall i. Int -> Prop i
+rows = prop (propName "rows") (Just $ attrName "rows")
 
 colSpan :: forall i. Int -> Prop i
 colSpan = prop (propName "colSpan") (Just $ attrName "colspan")

--- a/src/Halogen/HTML/Properties/Indexed.purs
+++ b/src/Halogen/HTML/Properties/Indexed.purs
@@ -18,6 +18,8 @@ module Halogen.HTML.Properties.Indexed
   , alt
   , charset
   , class_, classes
+  , cols
+  , rows
   , colSpan
   , rowSpan
   , for
@@ -50,7 +52,7 @@ module Halogen.HTML.Properties.Indexed
   , placeholder
   , autocomplete
   , autofocus
-  
+
   , initializer
   , finalizer
 
@@ -100,6 +102,12 @@ class_ = unsafeCoerce P.class_
 
 classes :: forall r i. Array ClassName -> IProp (class :: I | r) i
 classes = unsafeCoerce P.classes
+
+cols :: forall r i. Int -> IProp (cols :: I | r) i
+cols = unsafeCoerce P.cols
+
+rows :: forall r i. Int -> IProp (rows :: I | r) i
+rows = unsafeCoerce P.rows
 
 colSpan :: forall r i. Int -> IProp (colSpan :: I | r) i
 colSpan = unsafeCoerce P.colSpan


### PR DESCRIPTION
`Halogen.HTML.Element.Indexed.textarea` currently accepts the `rows` and `cols` properties, yet they are undefined in both standard and indexed forms. This branch adds them.

I tested these additions with Ajax.Example's `H.textarea`, and my inputs of `P.rows 10` and `P.cols 50` properly rendered as attributes in the `textarea` tag on the browser.