### PR TITLE
Remove *most* warnings generated by purescript 0.8.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "contributors": [
     "Phil Freeman <paf31@cantab.net>",
     "John A. De Goes <john@degoes.net>",
-    "Gary Burgess <gary.burgess@gmail.com>"
+    "Gary Burgess <gary.burgess@gmail.com>",
+    "Trevis Elser <trevis.elser@gmail.com>"
   ],
   "scripts": {
     "postinstall": "bower install",
@@ -28,7 +29,7 @@
     "gulp-jscs": "^1.6.0",
     "gulp-jshint": "^1.11.2",
     "gulp-purescript": "^0.7.0",
-    "purescript": "^0.7.6",
+    "purescript": "^0.8.0",
     "rimraf": "^2.4.1",
     "webpack-stream": "^2.0.0"
   },

--- a/src/Halogen.purs
+++ b/src/Halogen.purs
@@ -12,15 +12,15 @@ module Halogen
   , module Data.NaturalTransformation
   ) where
 
-import Prelude
+import Prelude (..)
 
 import Data.NaturalTransformation (Natural())
 
-import Halogen.Component
-import Halogen.Driver
-import Halogen.Effects
-import Halogen.Query
-import qualified Halogen.HTML.Core as C
+import Halogen.Component (..)
+import Halogen.Driver (..)
+import Halogen.Effects (..)
+import Halogen.Query (..)
+import Halogen.HTML.Core (..) as C
 
 -- | A specialised version of the `Halogen.HTML.Core.HTML` type where `i` is
 -- | `* -> *` kinded to match the kind of a component query algebra.

--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -29,24 +29,24 @@ module Halogen.Component
   , queryComponent
   ) where
 
-import Prelude
+import Prelude (..)
 
 import Control.Apply ((<*))
 import Control.Bind ((=<<))
-import Control.Monad.Eff.Class (MonadEff)
+import Control.Monad.Eff.Class (class MonadEff)
 import Control.Monad.Free (Free(), foldFree, liftF, mapF)
-import Control.Monad.Free.Trans as FT
+import Control.Monad.Free.Trans (..) as FT
 import Control.Monad.State (State(), runState)
-import Control.Monad.State.Class as CMS
-import Control.Monad.State.Trans as CMS
+import Control.Monad.State.Class (..) as CMS
+import Control.Monad.State.Trans (..) as CMS
 
 import Data.Bifunctor (bimap, lmap, rmap)
 import Data.Functor.Coproduct (Coproduct(), coproduct, left, right)
-import Data.Map as M
+import Data.Map (..) as M
 import Data.Maybe (Maybe(..), maybe)
-import Data.Maybe.Unsafe as U
+import Data.Maybe.Unsafe (..) as U
 import Data.NaturalTransformation (Natural())
-import Data.Profunctor.Choice (Choice)
+import Data.Profunctor.Choice (class Choice)
 import Data.Traversable (for)
 import Data.Tuple (Tuple(..), snd)
 import Data.Void (Void())

--- a/src/Halogen/Driver.purs
+++ b/src/Halogen/Driver.purs
@@ -3,12 +3,12 @@ module Halogen.Driver
   , runUI
   ) where
 
-import Prelude
+import Prelude (..)
 
 import Control.Bind ((=<<))
 import Control.Coroutine (await)
 import Control.Coroutine.Stalling (($$?))
-import Control.Coroutine.Stalling as SCR
+import Control.Coroutine.Stalling (..) as SCR
 import Control.Monad.Aff (Aff(), forkAff)
 import Control.Monad.Aff.AVar (AVar(), makeVar, putVar, takeVar)
 import Control.Monad.Eff.Class (liftEff)
@@ -16,7 +16,7 @@ import Control.Monad.Free (runFreeM)
 import Control.Monad.Rec.Class (forever)
 import Control.Monad.State (runState)
 import Control.Monad.Trans (lift)
-import Control.Plus (Plus, empty)
+import Control.Plus (class Plus, empty)
 
 import Data.NaturalTransformation (Natural())
 import Data.Tuple (Tuple(..))

--- a/src/Halogen/HTML.purs
+++ b/src/Halogen/HTML.purs
@@ -9,12 +9,12 @@ module Halogen.HTML
   , module Halogen.HTML.Elements
   ) where
 
-import Prelude (Unit(), Functor, (<$>))
+import Prelude (Unit(), class Functor, (<$>))
 
 import Halogen.Component (Component(), SlotConstructor(..), transformChild)
 import Halogen.Component.ChildPath (ChildPath(), injSlot, injState)
-import Halogen.HTML.Core
-import Halogen.HTML.Elements
+import Halogen.HTML.Core (..)
+import Halogen.HTML.Elements (..)
 
 -- | Constructs a text node `HTML` value.
 text :: forall p i. String -> HTML p i

--- a/src/Halogen/HTML/Core.purs
+++ b/src/Halogen/HTML/Core.purs
@@ -11,7 +11,7 @@ module Halogen.HTML.Core
   , handler
   , handler'
 
-  , IsProp
+  , class IsProp
   , toPropString
 
   , Namespace()
@@ -39,9 +39,9 @@ module Halogen.HTML.Core
   , runClassName
   ) where
 
-import Prelude
+import Prelude (..)
 
-import Data.Bifunctor (Bifunctor, rmap)
+import Data.Bifunctor (class Bifunctor, rmap)
 import Data.Exists (Exists(), mkExists)
 import Data.ExistsR (ExistsR(), mkExistsR, runExistsR)
 import Data.Maybe (Maybe(..))

--- a/src/Halogen/HTML/Elements/Indexed.purs
+++ b/src/Halogen/HTML/Elements/Indexed.purs
@@ -126,8 +126,8 @@ module Halogen.HTML.Elements.Indexed
 
 import Halogen.HTML.Core (HTML())
 import Halogen.HTML.Properties.Indexed hiding (title)
-import qualified Halogen.HTML.Elements as E
-import qualified Halogen.HTML.Elements
+import Halogen.HTML.Elements (..) as E
+import Halogen.HTML.Elements
   ( a_
   , abbr_
   , acronym_
@@ -236,7 +236,7 @@ import qualified Halogen.HTML.Elements
   , video_
   ) as Unrefined
 
-import Unsafe.Coerce
+import Unsafe.Coerce (..)
 
 -- | An HTML element that admits children.
 type Node r p i
@@ -613,4 +613,3 @@ video = unsafeCoerce E.video
 
 wbr :: forall p i. Leaf () p i
 wbr = unsafeCoerce E.wbr
-

--- a/src/Halogen/HTML/Events.purs
+++ b/src/Halogen/HTML/Events.purs
@@ -6,7 +6,7 @@ module Halogen.HTML.Events
   , module Halogen.HTML.Events.Types
   ) where
 
-import Prelude
+import Prelude (..)
 
 import Halogen.Query (Action(), action)
 import Halogen.HTML.Events.Handler (EventHandler(), preventDefault, stopPropagation, stopImmediatePropagation)

--- a/src/Halogen/HTML/Events/Forms.purs
+++ b/src/Halogen/HTML/Events/Forms.purs
@@ -5,11 +5,11 @@ module Halogen.HTML.Events.Forms
   , onChecked
   ) where
 
-import Prelude
+import Prelude (..)
 
 import Data.Either (either)
 import Data.Foreign (toForeign)
-import Data.Foreign.Class (IsForeign, readProp)
+import Data.Foreign.Class (class IsForeign, readProp)
 import Data.Maybe (Maybe(..))
 
 import Halogen.HTML.Core (Prop(), eventName, handler')

--- a/src/Halogen/HTML/Events/Indexed.purs
+++ b/src/Halogen/HTML/Events/Indexed.purs
@@ -21,7 +21,7 @@ module Halogen.HTML.Events.Indexed
   , onContextMenu
   , onDoubleClick
   , onMouseDown
-  , onMouseEnter  
+  , onMouseEnter
   , onMouseLeave
   , onMouseMove
   , onMouseOver
@@ -40,16 +40,16 @@ module Halogen.HTML.Events.Indexed
   , module ExportedEvents
   ) where
 
-import Prelude
+import Prelude (..)
 
 import Unsafe.Coerce (unsafeCoerce)
 
 import Halogen.HTML.Events.Handler (EventHandler())
 import Halogen.HTML.Events.Types (Event(), MouseEvent(), FocusEvent(), KeyboardEvent())
 import Halogen.HTML.Properties.Indexed (IProp(), I())
-import qualified Halogen.HTML.Events (input, input_) as ExportedEvents
-import qualified Halogen.HTML.Events as E
-import qualified Halogen.HTML.Events.Forms as E
+import Halogen.HTML.Events (input, input_) as ExportedEvents
+import Halogen.HTML.Events (..) as E
+import Halogen.HTML.Events.Forms (..) as E
 
 type IEventProp r e i = (Event e -> EventHandler i) -> IProp r i
 

--- a/src/Halogen/HTML/Indexed.purs
+++ b/src/Halogen/HTML/Indexed.purs
@@ -5,6 +5,6 @@ module Halogen.HTML.Indexed
   , module HTMLPublic
   ) where
 
-import qualified Halogen.HTML (text, slot, slot') as HTMLPublic
-import Halogen.HTML.Core
-import Halogen.HTML.Elements.Indexed
+import Halogen.HTML (text, slot, slot') as HTMLPublic
+import Halogen.HTML.Core (..)
+import Halogen.HTML.Elements.Indexed (..)

--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -36,14 +36,14 @@ module Halogen.HTML.Properties
   , LengthLiteral(..)
   ) where
 
-import Prelude
+import Prelude (..)
 
 import Data.Maybe (Maybe(..))
 import Data.String (joinWith)
 
 import DOM.HTML.Types (HTMLElement())
 
-import Halogen.HTML.Core (Prop(..), ClassName(), IsProp, prop, propName, attrName, runClassName)
+import Halogen.HTML.Core (Prop(..), ClassName(), class IsProp, prop, propName, attrName, runClassName)
 
 data LengthLiteral
   = Pixels Int

--- a/src/Halogen/HTML/Properties/Indexed.purs
+++ b/src/Halogen/HTML/Properties/Indexed.purs
@@ -67,19 +67,19 @@ module Halogen.HTML.Properties.Indexed
   , GlobalProperties()
   ) where
 
-import Prelude
+import Prelude (..)
 
-import Data.Foldable
-import Data.Tuple
-import qualified Data.Array as A
+import Data.Foldable (..)
+import Data.Tuple (..)
+import Data.Array (..) as A
 
 import Unsafe.Coerce (unsafeCoerce)
 
 import DOM.HTML.Types (HTMLElement())
 
 import Halogen.HTML.Core (Prop(), ClassName())
-import qualified Halogen.HTML.Properties (LengthLiteral(..)) as PExport
-import qualified Halogen.HTML.Properties as P
+import Halogen.HTML.Properties (LengthLiteral(..)) as PExport
+import Halogen.HTML.Properties (..) as P
 
 -- | The phantom row `r` can be thought of as a context which is synthesized in the
 -- | course of constructing a refined HTML expression.

--- a/src/Halogen/HTML/Renderer/String.purs
+++ b/src/Halogen/HTML/Renderer/String.purs
@@ -1,6 +1,6 @@
 module Halogen.HTML.Renderer.String (renderHTML) where
 
-import Prelude
+import Prelude (..)
 
 import Data.Array (mapMaybe)
 import Data.Exists (runExists)

--- a/src/Halogen/HTML/Renderer/VirtualDOM.purs
+++ b/src/Halogen/HTML/Renderer/VirtualDOM.purs
@@ -2,7 +2,7 @@ module Halogen.HTML.Renderer.VirtualDOM
   ( renderHTML
   ) where
 
-import Prelude
+import Prelude (..)
 
 import Control.Monad.Aff (Aff(), runAff)
 import Control.Monad.Eff (Eff())
@@ -19,7 +19,7 @@ import Data.Nullable (toNullable)
 import Halogen.Effects (HalogenEffects())
 import Halogen.HTML.Core (HTML(..), Prop(..), PropF(..), HandlerF(..), runNamespace, runTagName, runPropName, runAttrName, runEventName)
 import Halogen.HTML.Events.Handler (runEventHandler)
-import qualified Halogen.Internal.VirtualDOM as V
+import Halogen.Internal.VirtualDOM (..) as V
 
 -- | Render a `HTML` document to a virtual DOM node
 -- |

--- a/src/Halogen/Query.purs
+++ b/src/Halogen/Query.purs
@@ -18,16 +18,16 @@ module Halogen.Query
   , module Halogen.Query.StateF
   ) where
 
-import Prelude (Unit(), unit, id, Functor, (<<<))
+import Prelude (Unit(), unit, id, class Functor, (<<<))
 
-import Control.Alt (Alt)
+import Control.Alt (class Alt)
 import Control.Monad.Aff (Aff())
-import Control.Monad.Aff.Class (MonadAff, liftAff)
+import Control.Monad.Aff.Class (class MonadAff, liftAff)
 import Control.Monad.Eff (Eff())
-import Control.Monad.Eff.Class (MonadEff, liftEff)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Free (Free(), liftF)
 
-import Data.Inject (Inject)
+import Data.Inject (class Inject)
 
 import Halogen.Query.EventSource (EventSource(), ParentEventSource(), eventSource, eventSource_, toParentEventSource)
 import Halogen.Query.HalogenF (HalogenF(), HalogenFP(..))

--- a/src/Halogen/Query/HalogenF.purs
+++ b/src/Halogen/Query/HalogenF.purs
@@ -7,12 +7,12 @@ module Halogen.Query.HalogenF
 
 import Prelude
 
-import Control.Alt (Alt)
-import Control.Plus (Plus)
+import Control.Alt (class Alt)
+import Control.Plus (class Plus)
 import Control.Monad.Free.Trans (hoistFreeT, bimapFreeT)
 
 import Data.Bifunctor (lmap)
-import Data.Inject (Inject)
+import Data.Inject (class Inject)
 import Data.Maybe (Maybe(..))
 import Data.NaturalTransformation (Natural())
 

--- a/src/Halogen/Util.purs
+++ b/src/Halogen/Util.purs
@@ -4,11 +4,11 @@ module Halogen.Util
   , onLoad
   ) where
 
-import Prelude
+import Prelude (..)
 
 import Control.Bind ((<=<), (=<<))
 import Control.Monad.Eff (Eff())
-import Control.Monad.Eff.Class (MonadEff, liftEff)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
 
 import Data.Maybe (Maybe(..))
 import Data.Nullable (toMaybe)


### PR DESCRIPTION
- Warnings about imports made redundant by whole module imports were left alone since it seemed that it often had to do with re-exports.
- Everywhere there was a whole module import I silenced the warning by using (..) rather than use the suggested explicit imports to keep semantics the same (this is a non-trivial codebase and I'm not going to pretend to have grokked all of the inner workings). 
- Fixed all of the missing class keyword warnings

Thanks for the awesome project everyone. This was motivated by using the rc and halogen at work. Saw all the warnings and thought I'd contrib something. Let me know if I should change anything! 