### PR TITLE
Add FunctorEff and FunctorAff classes

### DIFF
--- a/docs/Halogen/Query/HalogenF.md
+++ b/docs/Halogen/Query/HalogenF.md
@@ -15,6 +15,8 @@ The Halogen component algebra
 ##### Instances
 ``` purescript
 (Functor g) => Functor (HalogenFP e s f g)
+(FunctorEff eff g) => FunctorEff eff (HalogenFP e s f g)
+(FunctorAff eff g) => FunctorAff eff (HalogenFP e s f g)
 Inject (StateF s) (HalogenFP e s f g)
 Inject g (HalogenFP e s f g)
 (Functor g) => Alt (HalogenFP e s f g)

--- a/src/Data/Functor/Aff.purs
+++ b/src/Data/Functor/Aff.purs
@@ -1,0 +1,14 @@
+module Data.Functor.Aff where
+
+import Prelude
+import Control.Monad.Aff (Aff())
+import Control.Monad.Free (Free(), liftF)
+
+class (Functor f) <= FunctorAff eff f where
+  liftAff :: forall a. Aff eff a -> f a
+
+instance functorAffAff :: FunctorAff eff (Aff eff) where
+  liftAff = id
+
+instance functorAffFree :: (FunctorAff eff f) => FunctorAff eff (Free f) where
+  liftAff = liftF <<< liftAff

--- a/src/Data/Functor/Eff.purs
+++ b/src/Data/Functor/Eff.purs
@@ -1,0 +1,19 @@
+module Data.Functor.Eff where
+
+import Prelude
+import Control.Monad.Eff (Eff())
+import Control.Monad.Eff.Class as EF
+import Control.Monad.Aff (Aff())
+import Control.Monad.Free (Free(), liftF)
+
+class (Functor f) <= FunctorEff eff f where
+  liftEff :: forall a. Eff eff a -> f a
+
+instance functorEffEff :: FunctorEff eff (Eff eff) where
+  liftEff = id
+
+instance functorEffAff :: FunctorEff eff (Aff eff) where
+  liftEff = EF.liftEff
+
+instance functorEffFree :: (FunctorEff eff f) => FunctorEff eff (Free f) where
+  liftEff = liftF <<< liftEff

--- a/src/Halogen/Query/HalogenF.purs
+++ b/src/Halogen/Query/HalogenF.purs
@@ -12,6 +12,8 @@ import Control.Plus (Plus)
 import Control.Monad.Free.Trans (hoistFreeT, bimapFreeT)
 
 import Data.Bifunctor (lmap)
+import Data.Functor.Aff (FunctorAff, liftAff)
+import Data.Functor.Eff (FunctorEff, liftEff)
 import Data.Inject (Inject)
 import Data.Maybe (Maybe(..))
 import Data.NaturalTransformation (Natural())
@@ -35,6 +37,12 @@ instance functorHalogenF :: (Functor g) => Functor (HalogenFP e s f g) where
       SubscribeHF es a -> SubscribeHF es (f a)
       QueryHF q -> QueryHF (map f q)
       HaltHF -> HaltHF
+
+instance functorEffHalogenF :: (FunctorEff eff g) => FunctorEff eff (HalogenFP e s f g) where
+  liftEff = QueryHF <<< liftEff
+
+instance functorAffHalogenF :: (FunctorAff eff g) => FunctorAff eff (HalogenFP e s f g) where
+  liftAff = QueryHF <<< liftAff
 
 instance injectStateHF :: Inject (StateF s) (HalogenFP e s f g) where
   inj = StateHF


### PR DESCRIPTION
@jdegoes I figured we could include these here for now, since it's the motivating case. Maybe they can be adopted elsewhere if they turn out to be generally useful - but this approach seems _great_ so far. I've managed to do away with all the `liftH $ liftAff'` type stuff I've tried it on so far in `slamdata`.

It's also a drop in replacement for any instance of the `Monad` version of `liftEff`/`liftAff` that I've found so far. Can you think of a case where the `Monad` constraint would actually be useful?