### PR TITLE
Make form EventHandler types more general

### DIFF
--- a/docs/Halogen/HTML/Events/Forms.md
+++ b/docs/Halogen/HTML/Events/Forms.md
@@ -5,7 +5,7 @@ Convenience functions for working with form events.
 #### `onValueChange`
 
 ``` purescript
-onValueChange :: forall f. (String -> EventHandler (f Unit)) -> Prop (f Unit)
+onValueChange :: forall i. (String -> EventHandler i) -> Prop i
 ```
 
 Attaches an event handler which will produce an input when the value of an
@@ -14,7 +14,7 @@ input field changes.
 #### `onValueInput`
 
 ``` purescript
-onValueInput :: forall f. (String -> EventHandler (f Unit)) -> Prop (f Unit)
+onValueInput :: forall i. (String -> EventHandler i) -> Prop i
 ```
 
 Attaches an event handler which will fire on input.
@@ -22,7 +22,7 @@ Attaches an event handler which will fire on input.
 #### `onChecked`
 
 ``` purescript
-onChecked :: forall f. (Boolean -> EventHandler (f Unit)) -> Prop (f Unit)
+onChecked :: forall i. (Boolean -> EventHandler i) -> Prop i
 ```
 
 Attaches an event handler which will fire when a checkbox is checked or

--- a/docs/Halogen/HTML/Events/Indexed.md
+++ b/docs/Halogen/HTML/Events/Indexed.md
@@ -213,19 +213,19 @@ onFocusOut :: forall r i. IEventProp (onFocusOut :: I | r) FocusEvent i
 #### `onValueChange`
 
 ``` purescript
-onValueChange :: forall r f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onChange :: I | r) (f Unit)
+onValueChange :: forall r i. (String -> EventHandler i) -> IProp (value :: I, onChange :: I | r) i
 ```
 
 #### `onValueInput`
 
 ``` purescript
-onValueInput :: forall r f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onInput :: I | r) (f Unit)
+onValueInput :: forall r i. (String -> EventHandler i) -> IProp (value :: I, onInput :: I | r) i
 ```
 
 #### `onChecked`
 
 ``` purescript
-onChecked :: forall r f. (Boolean -> EventHandler (f Unit)) -> IProp (checked :: I, onChange :: I | r) (f Unit)
+onChecked :: forall r i. (Boolean -> EventHandler i) -> IProp (checked :: I, onChange :: I | r) i
 ```
 
 

--- a/src/Halogen/HTML/Events/Forms.purs
+++ b/src/Halogen/HTML/Events/Forms.purs
@@ -17,19 +17,19 @@ import Halogen.HTML.Events.Handler (EventHandler())
 
 -- | Attaches event handler to event `key` with getting `prop` field as an
 -- | argument of `handler`.
-addForeignPropHandler :: forall f value. (IsForeign value) => String -> String -> (value -> EventHandler (f Unit)) -> Prop (f Unit)
+addForeignPropHandler :: forall i value. (IsForeign value) => String -> String -> (value -> EventHandler i) -> Prop i
 addForeignPropHandler key prop f = handler' (eventName key) (either (const $ pure Nothing) (map Just <<< f) <<< readProp prop <<< toForeign <<< _.target)
 
 -- | Attaches an event handler which will produce an input when the value of an
 -- | input field changes.
-onValueChange :: forall f. (String -> EventHandler (f Unit)) -> Prop (f Unit)
+onValueChange :: forall i. (String -> EventHandler i) -> Prop i
 onValueChange = addForeignPropHandler "change" "value"
 
 -- | Attaches an event handler which will fire on input.
-onValueInput :: forall f. (String -> EventHandler (f Unit)) -> Prop (f Unit)
+onValueInput :: forall i. (String -> EventHandler i) -> Prop i
 onValueInput = addForeignPropHandler "input" "value"
 
 -- | Attaches an event handler which will fire when a checkbox is checked or
 -- | unchecked.
-onChecked :: forall f. (Boolean -> EventHandler (f Unit)) -> Prop (f Unit)
+onChecked :: forall i. (Boolean -> EventHandler i) -> Prop i
 onChecked = addForeignPropHandler "change" "checked"

--- a/src/Halogen/HTML/Events/Indexed.purs
+++ b/src/Halogen/HTML/Events/Indexed.purs
@@ -21,7 +21,7 @@ module Halogen.HTML.Events.Indexed
   , onContextMenu
   , onDoubleClick
   , onMouseDown
-  , onMouseEnter  
+  , onMouseEnter
   , onMouseLeave
   , onMouseMove
   , onMouseOver
@@ -155,11 +155,11 @@ onFocusIn = unsafeCoerce E.onFocusIn
 onFocusOut :: forall r i. IEventProp (onFocusOut :: I | r) FocusEvent i
 onFocusOut = unsafeCoerce E.onFocusOut
 
-onValueChange :: forall r f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onChange :: I | r) (f Unit)
+onValueChange :: forall r i. (String -> EventHandler i) -> IProp (value :: I, onChange :: I | r) i
 onValueChange = unsafeCoerce E.onValueChange
 
-onValueInput :: forall r f. (String -> EventHandler (f Unit)) -> IProp (value :: I, onInput :: I | r) (f Unit)
+onValueInput :: forall r i. (String -> EventHandler i) -> IProp (value :: I, onInput :: I | r) i
 onValueInput = unsafeCoerce E.onValueInput
 
-onChecked :: forall r f. (Boolean -> EventHandler (f Unit)) -> IProp (checked :: I, onChange :: I | r) (f Unit)
+onChecked :: forall r i. (Boolean -> EventHandler i) -> IProp (checked :: I, onChange :: I | r) i
 onChecked = unsafeCoerce E.onChecked


### PR DESCRIPTION
Resolves #263

Sorry this took so long to get to @russellmcc. I still would still like to extract the HTML DSL entirely but that’s going to take a little more work to get right. There’s no reason not to do this fix now though, as I’m not really sure why they were specialised to `f Unit` in the first place!