### PR TITLE
readonly -> readOnly

### DIFF
--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -126,7 +126,7 @@ required :: forall i. Boolean -> Prop i
 required = prop (propName "required") (Just $ attrName "required")
 
 readonly :: forall i. Boolean -> Prop i
-readonly = prop (propName "readonly") (Just $ attrName "readonly")
+readonly = prop (propName "readOnly") (Just $ attrName "readonly")
 
 spellcheck :: forall i. Boolean -> Prop i
 spellcheck = prop (propName "spellcheck") (Just $ attrName "spellcheck")


### PR DESCRIPTION
@garyb Is this ok? I've left function name same with attribute not property because
+ I don't want to change API
+ `class_` uses `className` property name. 