### PR TITLE
Switch to more reliable Travis build (trusty)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
-sudo: false
+dist: trusty
+sudo: required
 node_js:
-  - 4
+  - 5
 install:
   - npm install
 script:


### PR DESCRIPTION
We've found with the `slamdata` build, as well as `purescript-markdown`, that Travis's `trusty` image is much faster and more reliable for PureScript builds than the default.