### PR TITLE
Render rewrite

### DIFF
--- a/src/Halogen/HTML/Renderer/VirtualDOM.purs
+++ b/src/Halogen/HTML/Renderer/VirtualDOM.purs
@@ -13,6 +13,7 @@ import Data.Exists (runExists)
 import Data.ExistsR (runExistsR)
 import Data.Foldable (foldl, foldMap)
 import Data.Function (runFn2)
+import Data.Lazy (force)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Monoid (mempty)
 import Data.Nullable (toNullable)
@@ -52,7 +53,7 @@ renderTree f =
               tag = runTagName name
               key = toNullable $ foldl findKey Nothing props
           in V.vnode ns' tag key (foldMap (renderProp f) props) (map go els)
-    in go tree.html
+    in go (force tree.html)
 
 renderProp :: forall f eff. (forall i. f i -> Aff (HalogenEffects eff) i) -> Prop (f Unit) -> V.Props
 renderProp _ (Prop e) = runExists (\(PropF key value _) ->


### PR DESCRIPTION
This tracks from @garyb's 0.6 branch. My unscientific perf test is to create a 30x30 grid of counter components (900 child components), and then click a button 10 times. In the old code, I was measuring ~2100ms in garbage collection, and ~1400ms in executing the click handler (so around 350ms per click or so). In this updated code I'm measuring 200-400ms in garbage collection, and ~650ms in the click handler (so around 85ms per click). It's still slower than I'd like, but I don't know how much faster we'll get. At this point the majority of the time is spent in `Data.Map` inserts and deletes, and I don't know how I can minimize those anymore than I have.