### PR TITLE
Fix indexed ref property, use refine over direct coerce

### DIFF
--- a/examples/lifecycle/src/Child.purs
+++ b/examples/lifecycle/src/Child.purs
@@ -17,7 +17,7 @@ import DOM.HTML.Types (HTMLElement())
 
 data Query a = Initialize a
              | Finalize a
-             | Ref HTMLElement a
+             | Ref (Maybe HTMLElement) a
 
 type Slot = Unit
 
@@ -57,7 +57,7 @@ child = lifecycleParentComponent
     id <- get
     fromAff $ log ("Finalize Child " <> show id)
     pure next
-  eval (Ref el next) = do
+  eval (Ref _ next) = do
     id <- get
     fromAff $ log ("Ref Child " <> show id)
     pure next
@@ -80,7 +80,7 @@ cell = lifecycleComponent
     id <- get
     fromAff $ log ("Initialize Cell " <> show id)
     pure next
-  eval (Ref el next) = do
+  eval (Ref _ next) = do
     id <- get
     fromAff $ log ("Ref Cell " <> show id)
     pure next

--- a/src/Halogen/HTML/Events/Indexed.purs
+++ b/src/Halogen/HTML/Events/Indexed.purs
@@ -52,146 +52,153 @@ import Prelude
 
 import Unsafe.Coerce (unsafeCoerce)
 
+import Halogen.HTML.Core (Prop())
+import Halogen.HTML.Events (input, input_) as ExportedEvents
+import Halogen.HTML.Events as E
+import Halogen.HTML.Events.Forms as F
 import Halogen.HTML.Events.Handler (EventHandler())
 import Halogen.HTML.Events.Types (Event(), MouseEvent(), DragEvent(), FocusEvent(), KeyboardEvent())
 import Halogen.HTML.Properties.Indexed (IProp(), I())
-import Halogen.HTML.Events (input, input_) as ExportedEvents
-import Halogen.HTML.Events as E
-import Halogen.HTML.Events.Forms as E
 
 type IEventProp r e i = (Event e -> EventHandler i) -> IProp r i
 
+refine :: forall e i r. E.EventProp e i -> IEventProp r e i
+refine = unsafeCoerce
+
+refine' :: forall a r i. (a -> Prop i) -> a -> IProp r i
+refine' = unsafeCoerce
+
 onAbort :: forall r i. IEventProp (onAbort :: I | r) () i
-onAbort = unsafeCoerce E.onAbort
+onAbort = refine E.onAbort
 
 onBeforeUnload :: forall r i. IEventProp (onBeforeUnload :: I | r) () i
-onBeforeUnload = unsafeCoerce E.onBeforeUnload
+onBeforeUnload = refine E.onBeforeUnload
 
 onError :: forall r i. IEventProp (onError :: I | r) () i
-onError = unsafeCoerce E.onError
+onError = refine E.onError
 
 onHashChange :: forall r i. IEventProp (onHashChange :: I | r) () i
-onHashChange = unsafeCoerce E.onHashChange
+onHashChange = refine E.onHashChange
 
 onLoad :: forall r i. IEventProp (onLoad :: I | r) () i
-onLoad = unsafeCoerce E.onLoad
+onLoad = refine E.onLoad
 
 onPageShow :: forall r i. IEventProp (onPageShow :: I | r) () i
-onPageShow = unsafeCoerce E.onPageShow
+onPageShow = refine E.onPageShow
 
 onPageHide :: forall r i. IEventProp (onPageHide :: I | r) () i
-onPageHide = unsafeCoerce E.onPageHide
+onPageHide = refine E.onPageHide
 
 onResize :: forall r i. IEventProp (onResize :: I | r) () i
-onResize = unsafeCoerce E.onResize
+onResize = refine E.onResize
 
 onScroll :: forall r i. IEventProp (onScroll :: I | r) () i
-onScroll = unsafeCoerce E.onScroll
+onScroll = refine E.onScroll
 
 onUnload :: forall r i. IEventProp (onUnload :: I | r) () i
-onUnload = unsafeCoerce E.onUnload
+onUnload = refine E.onUnload
 
 onChange :: forall r i. IEventProp (onChange :: I | r) () i
-onChange = unsafeCoerce E.onChange
+onChange = refine E.onChange
 
 onInput :: forall r i. IEventProp (onInput :: I | r) () i
-onInput = unsafeCoerce E.onInput
+onInput = refine E.onInput
 
 onInvalid :: forall r i. IEventProp (onInvalid :: I | r) () i
-onInvalid = unsafeCoerce E.onInvalid
+onInvalid = refine E.onInvalid
 
 onReset :: forall r i. IEventProp (onReset :: I | r) () i
-onReset = unsafeCoerce E.onReset
+onReset = refine E.onReset
 
 onSearch :: forall r i. IEventProp (onSearch :: I | r) () i
-onSearch = unsafeCoerce E.onSearch
+onSearch = refine E.onSearch
 
 onSelect :: forall r i. IEventProp (onSelect :: I | r) () i
-onSelect = unsafeCoerce E.onSelect
+onSelect = refine E.onSelect
 
 onSubmit :: forall r i. IEventProp (onSubmit :: I | r) () i
-onSubmit = unsafeCoerce E.onSubmit
+onSubmit = refine E.onSubmit
 
 onClick :: forall r i. IEventProp (onClick :: I | r) MouseEvent i
-onClick = unsafeCoerce E.onClick
+onClick = refine E.onClick
 
 onContextMenu :: forall r i. IEventProp (onContextMenu :: I | r) MouseEvent i
-onContextMenu = unsafeCoerce E.onContextMenu
+onContextMenu = refine E.onContextMenu
 
 onDoubleClick :: forall r i. IEventProp (onDoubleClick :: I | r) MouseEvent i
-onDoubleClick = unsafeCoerce E.onDoubleClick
+onDoubleClick = refine E.onDoubleClick
 
 onMouseDown :: forall r i. IEventProp (onMouseDown :: I | r) MouseEvent i
-onMouseDown = unsafeCoerce E.onMouseDown
+onMouseDown = refine E.onMouseDown
 
 onMouseEnter :: forall r i. IEventProp (onMouseEnter :: I | r) MouseEvent i
-onMouseEnter = unsafeCoerce E.onMouseEnter
+onMouseEnter = refine E.onMouseEnter
 
 onMouseLeave :: forall r i. IEventProp (onMouseLeave :: I | r) MouseEvent i
-onMouseLeave = unsafeCoerce E.onMouseLeave
+onMouseLeave = refine E.onMouseLeave
 
 onMouseMove :: forall r i. IEventProp (onMouseMove :: I | r) MouseEvent i
-onMouseMove = unsafeCoerce E.onMouseMove
+onMouseMove = refine E.onMouseMove
 
 onMouseOver :: forall r i. IEventProp (onMouseOver :: I | r) MouseEvent i
-onMouseOver = unsafeCoerce E.onMouseOver
+onMouseOver = refine E.onMouseOver
 
 onMouseOut :: forall r i. IEventProp (onMouseOut :: I | r) MouseEvent i
-onMouseOut = unsafeCoerce E.onMouseOut
+onMouseOut = refine E.onMouseOut
 
 onMouseUp :: forall r i. IEventProp (onMouseUp :: I | r) MouseEvent i
-onMouseUp = unsafeCoerce E.onMouseUp
+onMouseUp = refine E.onMouseUp
 
 onKeyDown :: forall r i. IEventProp (onKeyDown :: I | r) KeyboardEvent i
-onKeyDown = unsafeCoerce E.onKeyDown
+onKeyDown = refine E.onKeyDown
 
 onKeyPress :: forall r i. IEventProp (onKeyPress :: I | r) KeyboardEvent i
-onKeyPress = unsafeCoerce E.onKeyPress
+onKeyPress = refine E.onKeyPress
 
 onKeyUp :: forall r i. IEventProp (onKeyUp :: I | r) KeyboardEvent i
-onKeyUp = unsafeCoerce E.onKeyUp
+onKeyUp = refine E.onKeyUp
 
 onBlur :: forall r i. IEventProp (onBlur :: I | r) FocusEvent i
-onBlur = unsafeCoerce E.onBlur
+onBlur = refine E.onBlur
 
 onFocus :: forall r i. IEventProp (onFocus :: I | r) FocusEvent i
-onFocus = unsafeCoerce E.onFocus
+onFocus = refine E.onFocus
 
 onFocusIn :: forall r i. IEventProp (onFocusIn :: I | r) FocusEvent i
-onFocusIn = unsafeCoerce E.onFocusIn
+onFocusIn = refine E.onFocusIn
 
 onFocusOut :: forall r i. IEventProp (onFocusOut :: I | r) FocusEvent i
-onFocusOut = unsafeCoerce E.onFocusOut
+onFocusOut = refine E.onFocusOut
 
 onDrag :: forall r i. IEventProp r DragEvent i
-onDrag = unsafeCoerce E.onDrag
+onDrag = refine E.onDrag
 
 onDragEnd :: forall r i. IEventProp r DragEvent i
-onDragEnd = unsafeCoerce E.onDragEnd
+onDragEnd = refine E.onDragEnd
 
 onDragExit :: forall r i. IEventProp r DragEvent i
-onDragExit = unsafeCoerce E.onDragExit
+onDragExit = refine E.onDragExit
 
 onDragEnter :: forall r i. IEventProp r DragEvent i
-onDragEnter = unsafeCoerce E.onDragEnter
+onDragEnter = refine E.onDragEnter
 
 onDragLeave :: forall r i. IEventProp r DragEvent i
-onDragLeave = unsafeCoerce E.onDragLeave
+onDragLeave = refine E.onDragLeave
 
 onDragOver :: forall r i. IEventProp r DragEvent i
-onDragOver = unsafeCoerce E.onDragOver
+onDragOver = refine E.onDragOver
 
 onDragStart :: forall r i. IEventProp r DragEvent i
-onDragStart = unsafeCoerce E.onDragStart
+onDragStart = refine E.onDragStart
 
 onDrop :: forall r i. IEventProp r DragEvent i
-onDrop = unsafeCoerce E.onDrop
+onDrop = refine E.onDrop
 
 onValueChange :: forall r i. (String -> EventHandler i) -> IProp (value :: I, onChange :: I | r) i
-onValueChange = unsafeCoerce E.onValueChange
+onValueChange = refine' F.onValueChange
 
 onValueInput :: forall r i. (String -> EventHandler i) -> IProp (value :: I, onInput :: I | r) i
-onValueInput = unsafeCoerce E.onValueInput
+onValueInput = refine' F.onValueInput
 
 onChecked :: forall r i. (Boolean -> EventHandler i) -> IProp (checked :: I, onChange :: I | r) i
-onChecked = unsafeCoerce E.onChecked
+onChecked = refine' F.onChecked

--- a/src/Halogen/HTML/Properties/Indexed.purs
+++ b/src/Halogen/HTML/Properties/Indexed.purs
@@ -70,9 +70,10 @@ module Halogen.HTML.Properties.Indexed
 
 import Prelude
 
-import Data.Foldable
-import Data.Tuple
 import Data.Array as A
+import Data.Foldable (intercalate)
+import Data.Maybe (Maybe())
+import Data.Tuple (Tuple(..))
 
 import Unsafe.Coerce (unsafeCoerce)
 
@@ -89,62 +90,65 @@ newtype IProp (r :: # *) i = IProp (Prop i)
 -- | A dummy type to use in the phantom row.
 data I
 
+refine :: forall a r i. (a -> Prop i) -> a -> IProp r i
+refine = unsafeCoerce
+
 key :: forall r i. String -> IProp (key :: I | r) i
-key = unsafeCoerce P.key
+key = refine P.key
 
 alt :: forall r i. String -> IProp (alt :: I | r) i
-alt = unsafeCoerce P.alt
+alt = refine P.alt
 
 charset :: forall r i. String -> IProp (charset :: I | r) i
-charset = unsafeCoerce P.charset
+charset = refine P.charset
 
 class_ :: forall r i. ClassName -> IProp (class :: I | r) i
-class_ = unsafeCoerce P.class_
+class_ = refine P.class_
 
 classes :: forall r i. Array ClassName -> IProp (class :: I | r) i
-classes = unsafeCoerce P.classes
+classes = refine P.classes
 
 cols :: forall r i. Int -> IProp (cols :: I | r) i
-cols = unsafeCoerce P.cols
+cols = refine P.cols
 
 rows :: forall r i. Int -> IProp (rows :: I | r) i
-rows = unsafeCoerce P.rows
+rows = refine P.rows
 
 colSpan :: forall r i. Int -> IProp (colSpan :: I | r) i
-colSpan = unsafeCoerce P.colSpan
+colSpan = refine P.colSpan
 
 rowSpan :: forall r i. Int -> IProp (rowSpan :: I | r) i
-rowSpan = unsafeCoerce P.rowSpan
+rowSpan = refine P.rowSpan
 
 for :: forall r i. String -> IProp (for :: I | r) i
-for = unsafeCoerce P.for
+for = refine P.for
 
 height :: forall r i. P.LengthLiteral -> IProp (height :: I | r) i
-height = unsafeCoerce P.height
+height = refine P.height
 
 width :: forall r i. P.LengthLiteral -> IProp (width :: I | r) i
-width = unsafeCoerce P.width
+width = refine P.width
 
 href :: forall r i. String -> IProp (href :: I | r) i
-href = unsafeCoerce P.href
+href = refine P.href
 
 id_ :: forall r i. String -> IProp (id :: I | r) i
-id_ = unsafeCoerce P.id_
+id_ = refine P.id_
 
 name :: forall r i. String -> IProp (name :: I | r) i
-name = unsafeCoerce P.name
+name = refine P.name
 
 rel :: forall r i. String -> IProp (rel :: I | r) i
-rel = unsafeCoerce P.rel
+rel = refine P.rel
 
 src :: forall r i. String -> IProp (src :: I | r) i
-src = unsafeCoerce P.src
+src = refine P.src
 
 target :: forall r i. String -> IProp (target :: I | r) i
-target = unsafeCoerce P.target
+target = refine P.target
 
 title :: forall r i. String -> IProp (title :: I | r) i
-title = unsafeCoerce P.title
+title = refine P.title
 
 data InputType
   = InputButton
@@ -199,7 +203,7 @@ renderInputType ty =
     InputWeek -> "week"
 
 inputType :: forall r i. InputType -> IProp (inputType :: I | r) i
-inputType = unsafeCoerce P.type_ <<< renderInputType
+inputType = refine P.type_ <<< renderInputType
 
 data MenuType
   = MenuList
@@ -214,7 +218,7 @@ renderMenuType ty =
     MenuToolbar -> "toolbar"
 
 menuType :: forall r i. MenuType -> IProp (menuType :: I | r) i
-menuType = unsafeCoerce P.type_ <<< renderMenuType
+menuType = refine P.type_ <<< renderMenuType
 
 data MenuitemType
   = MenuitemCommand
@@ -229,7 +233,7 @@ renderMenuitemType ty =
     MenuitemRadio -> "radio"
 
 menuitemType :: forall r i. MenuitemType -> IProp (menuitemType :: I | r) i
-menuitemType= unsafeCoerce P.type_ <<< renderMenuitemType
+menuitemType= refine P.type_ <<< renderMenuitemType
 
 type MediaType =
   { type :: String
@@ -249,7 +253,7 @@ renderMediaType ty = ty.type ++ "/" ++ ty.subtype ++ renderParameters ty.paramet
     renderParameter (Tuple k v) = k ++ "=" ++ v
 
 mediaType :: forall r i. MediaType -> IProp (mediaType :: I | r) i
-mediaType = unsafeCoerce P.type_ <<< renderMediaType
+mediaType = refine P.type_ <<< renderMediaType
 
 data ButtonType
   = ButtonButton
@@ -264,7 +268,7 @@ renderButtonType ty =
     ButtonReset -> "reset"
 
 buttonType :: forall r i. ButtonType -> IProp (buttonType :: I | r) i
-buttonType = unsafeCoerce P.type_ <<< renderButtonType
+buttonType = refine P.type_ <<< renderButtonType
 
 data CaseType
   = Uppercase
@@ -294,46 +298,46 @@ renderOrderedListType ty =
         Uppercase -> "A"
 
 olType :: forall r i. OrderedListType -> IProp (olType :: I | r) i
-olType = unsafeCoerce P.type_ <<< renderOrderedListType
+olType = refine P.type_ <<< renderOrderedListType
 
 value :: forall r i. String -> IProp (value :: I | r) i
-value = unsafeCoerce P.value
+value = refine P.value
 
 disabled :: forall r i. Boolean -> IProp (disabled :: I | r) i
-disabled = unsafeCoerce P.disabled
+disabled = refine P.disabled
 
 required :: forall r i. Boolean -> IProp (required :: I | r) i
-required = unsafeCoerce P.required
+required = refine P.required
 
 readonly :: forall r i. Boolean -> IProp (readonly :: I | r) i
-readonly = unsafeCoerce P.readonly
+readonly = refine P.readonly
 
 spellcheck :: forall r i. Boolean -> IProp (spellcheck :: I | r) i
-spellcheck = unsafeCoerce P.spellcheck
+spellcheck = refine P.spellcheck
 
 enabled :: forall r i. Boolean -> IProp (disabled :: I | r) i
 enabled = disabled <<< not
 
 checked :: forall r i. Boolean -> IProp (checked :: I | r) i
-checked = unsafeCoerce P.checked
+checked = refine P.checked
 
 selected :: forall r i. Boolean -> IProp (selected :: I | r) i
-selected = unsafeCoerce P.selected
+selected = refine P.selected
 
 placeholder :: forall r i. String -> IProp (placeholder :: I | r) i
-placeholder = unsafeCoerce P.placeholder
+placeholder = refine P.placeholder
 
 autocomplete :: forall r i. Boolean -> IProp (autocomplete :: I | r) i
-autocomplete = unsafeCoerce P.autocomplete
+autocomplete = refine P.autocomplete
 
 autofocus :: forall r i. Boolean -> IProp (autofocus :: I | r) i
-autofocus = unsafeCoerce P.autofocus
+autofocus = refine P.autofocus
 
 multiple :: forall r i. Boolean -> IProp (multiple :: I | r) i
-multiple = unsafeCoerce P.multiple
+multiple = refine P.multiple
 
-ref :: forall r i. (HTMLElement -> i) -> IProp (ref :: I | r) i
-ref = unsafeCoerce P.ref
+ref :: forall r i. (Maybe HTMLElement -> i) -> IProp (ref :: I | r) i
+ref = refine P.ref
 
 type GlobalAttributes r =
   ( id :: I

--- a/src/Halogen/HTML/Properties/Indexed/ARIA.purs
+++ b/src/Halogen/HTML/Properties/Indexed/ARIA.purs
@@ -40,114 +40,118 @@ import Prelude
 
 import Unsafe.Coerce (unsafeCoerce)
 
+import Halogen.HTML.Core (Prop())
 import Halogen.HTML.Properties.Indexed (IProp())
 import Halogen.HTML.Properties.ARIA as P
 
+refine :: forall a r i. (a -> Prop i) -> a -> IProp r i
+refine = unsafeCoerce
+
 activeDescendant :: forall r i. String -> IProp r i
-activeDescendant = unsafeCoerce P.activeDescendant
+activeDescendant = refine P.activeDescendant
 
 atomic :: forall r i. String -> IProp r i
-atomic = unsafeCoerce P.atomic
+atomic = refine P.atomic
 
 autoComplete :: forall r i. String -> IProp r i
-autoComplete = unsafeCoerce P.autoComplete
+autoComplete = refine P.autoComplete
 
 busy :: forall r i. String -> IProp r i
-busy = unsafeCoerce P.busy
+busy = refine P.busy
 
 checked :: forall r i. String -> IProp r i
-checked = unsafeCoerce P.checked
+checked = refine P.checked
 
 controls :: forall r i. String -> IProp r i
-controls = unsafeCoerce P.controls
+controls = refine P.controls
 
 describedBy :: forall r i. String -> IProp r i
-describedBy = unsafeCoerce P.describedBy
+describedBy = refine P.describedBy
 
 disabled :: forall r i. String -> IProp r i
-disabled = unsafeCoerce P.disabled
+disabled = refine P.disabled
 
 dropEffect :: forall r i. String -> IProp r i
-dropEffect = unsafeCoerce P.dropEffect
+dropEffect = refine P.dropEffect
 
 expanded :: forall r i. String -> IProp r i
-expanded = unsafeCoerce P.expanded
+expanded = refine P.expanded
 
 flowTo :: forall r i. String -> IProp r i
-flowTo = unsafeCoerce P.flowTo
+flowTo = refine P.flowTo
 
 grabbed :: forall r i. String -> IProp r i
-grabbed = unsafeCoerce P.grabbed
+grabbed = refine P.grabbed
 
 hasPopup :: forall r i. String -> IProp r i
-hasPopup = unsafeCoerce P.hasPopup
+hasPopup = refine P.hasPopup
 
 hidden :: forall r i. String -> IProp r i
-hidden = unsafeCoerce P.hidden
+hidden = refine P.hidden
 
 invalid :: forall r i. String -> IProp r i
-invalid = unsafeCoerce P.invalid
+invalid = refine P.invalid
 
 label :: forall r i. String -> IProp r i
-label = unsafeCoerce P.label
+label = refine P.label
 
 labelledBy :: forall r i. String -> IProp r i
-labelledBy = unsafeCoerce P.labelledBy
+labelledBy = refine P.labelledBy
 
 level :: forall r i. String -> IProp r i
-level = unsafeCoerce P.level
+level = refine P.level
 
 live :: forall r i. String -> IProp r i
-live = unsafeCoerce P.live
+live = refine P.live
 
 multiLine :: forall r i. String -> IProp r i
-multiLine = unsafeCoerce P.multiLine
+multiLine = refine P.multiLine
 
 multiSelectable :: forall r i. String -> IProp r i
-multiSelectable = unsafeCoerce P.multiSelectable
+multiSelectable = refine P.multiSelectable
 
 orientation :: forall r i. String -> IProp r i
-orientation = unsafeCoerce P.orientation
+orientation = refine P.orientation
 
 owns :: forall r i. String -> IProp r i
-owns = unsafeCoerce P.owns
+owns = refine P.owns
 
 posInSet :: forall r i. String -> IProp r i
-posInSet = unsafeCoerce P.posInSet
+posInSet = refine P.posInSet
 
 pressed :: forall r i. String -> IProp r i
-pressed = unsafeCoerce P.pressed
+pressed = refine P.pressed
 
 readOnly :: forall r i. String -> IProp r i
-readOnly = unsafeCoerce P.readOnly
+readOnly = refine P.readOnly
 
 relevant :: forall r i. String -> IProp r i
-relevant = unsafeCoerce P.relevant
+relevant = refine P.relevant
 
 required :: forall r i. String -> IProp r i
-required = unsafeCoerce P.required
+required = refine P.required
 
 selected :: forall r i. String -> IProp r i
-selected = unsafeCoerce P.selected
+selected = refine P.selected
 
 setSize :: forall r i. String -> IProp r i
-setSize = unsafeCoerce P.setSize
+setSize = refine P.setSize
 
 sort :: forall r i. String -> IProp r i
-sort = unsafeCoerce P.sort
+sort = refine P.sort
 
 valueMax :: forall r i. String -> IProp r i
-valueMax = unsafeCoerce P.valueMax
+valueMax = refine P.valueMax
 
 valueMin :: forall r i. String -> IProp r i
-valueMin = unsafeCoerce P.valueMin
+valueMin = refine P.valueMin
 
 valueNow :: forall r i. String -> IProp r i
-valueNow = unsafeCoerce P.valueNow
+valueNow = refine P.valueNow
 
 valueText :: forall r i. String -> IProp r i
-valueText = unsafeCoerce P.valueText
+valueText = refine P.valueText
 
 role :: forall r i. String -> IProp r i
-role = unsafeCoerce P.role
+role = refine P.role
 


### PR DESCRIPTION
By typing `refine` a little more specifically than `unsafeCoerce` we should ensure this won't happen again.