### PR TITLE
Add tabIndex, add draggable to indexed props

### DIFF
--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -2,15 +2,16 @@
 module Halogen.HTML.Properties
   ( key
   , alt
+
   , charset
-  , class_
-  , classes
+  , class_, classes
   , cols
   , rows
   , colSpan
   , rowSpan
   , for
   , height
+  , width
   , href
   , id_
   , name
@@ -18,22 +19,28 @@ module Halogen.HTML.Properties
   , src
   , target
   , title
+
   , type_
+
   , value
-  , width
   , disabled
+  , enabled
+
   , required
   , readonly
   , spellcheck
-  , enabled
   , checked
   , selected
   , placeholder
   , autocomplete
   , autofocus
   , multiple
+
   , draggable
+  , tabIndex
+
   , ref
+
   , LengthLiteral(..)
   ) where
 
@@ -155,6 +162,9 @@ multiple = prop (propName "multiple") (Just $ attrName "multiple")
 
 draggable :: forall a. Boolean -> Prop a
 draggable = prop (propName "draggable") (Just $ attrName "draggable")
+
+tabIndex :: forall a. Int -> Prop a
+tabIndex = prop (propName "tabIndex") (Just $ attrName "tabindex")
 
 ref :: forall i. (Maybe HTMLElement -> i) -> Prop i
 ref = Ref

--- a/src/Halogen/HTML/Properties/Indexed.purs
+++ b/src/Halogen/HTML/Properties/Indexed.purs
@@ -55,6 +55,9 @@ module Halogen.HTML.Properties.Indexed
   , autofocus
   , multiple
 
+  , draggable
+  , tabIndex
+
   , ref
 
   , module PExport
@@ -337,6 +340,12 @@ autofocus = refine P.autofocus
 multiple :: forall r i. Boolean -> IProp (multiple :: I | r) i
 multiple = refine P.multiple
 
+draggable :: forall r i. Boolean -> IProp (draggable :: I | r) i
+draggable = refine P.draggable
+
+tabIndex :: forall r i. Int -> IProp (tabIndex :: I | r) i
+tabIndex = refine P.tabIndex
+
 ref :: forall r i. (Maybe HTMLElement -> i) -> IProp (ref :: I | r) i
 ref = refine P.ref
 
@@ -348,6 +357,8 @@ type GlobalAttributes r =
   , style :: I
   , spellcheck :: I
   , key :: I
+  , draggable :: I
+  , tabIndex :: I
   , ref :: I
   | r
   )


### PR DESCRIPTION
Resolves #298

Not sure why there wasn't an `Indexed` version of `draggable`, but there is now.

@natefaubion if you could take a look again? After that let's release the new version :white_check_mark: 