### PR TITLE
Use a phantom type to restrict LengthLiteral to correct length type

### DIFF
--- a/src/Halogen/HTML/Elements/Indexed.purs
+++ b/src/Halogen/HTML/Elements/Indexed.purs
@@ -125,6 +125,7 @@ module Halogen.HTML.Elements.Indexed
   ) where
 
 import Halogen.HTML.Core (HTML)
+import Halogen.HTML.Properties (Object, Element)
 import Halogen.HTML.Properties.Indexed hiding (title)
 import Halogen.HTML.Elements as E
 import Halogen.HTML.Elements
@@ -317,7 +318,7 @@ br = unsafeCoerce E.br
 button :: forall p i. Node (autofocus :: I, disabled :: I, form :: I, formaction :: I, formenctyp :: I, formmethod :: I, formnovalidate :: I, formtaget :: I, buttonType :: I, value :: I) p i
 button = unsafeCoerce E.button
 
-canvas :: forall p i. Leaf (width :: I, height :: I) p i
+canvas :: forall p i. Leaf (width :: Size Element, height :: Size Element) p i
 canvas = unsafeCoerce E.canvas
 
 caption :: forall p i. Node (align :: I, onScroll :: I) p i
@@ -374,7 +375,7 @@ dt = unsafeCoerce E.dt
 em :: forall p i. Node () p i
 em = unsafeCoerce E.em
 
-embed :: forall p i. Node (height :: I, src :: I, mediaType :: I, width :: I) p i
+embed :: forall p i. Node (height :: Size Object, src :: I, mediaType :: I, width :: Size Object) p i
 embed = unsafeCoerce E.embed
 
 fieldset :: forall p i. Node (disabled :: I, form :: I, onScroll :: I) p i
@@ -425,13 +426,13 @@ html = unsafeCoerce E.html
 i :: forall p i. Node () p i
 i = unsafeCoerce E.i
 
-iframe :: forall p i. NoninteractiveLeaf (onLoad :: I, sandbox :: I, scrolling :: I, src :: I, srcdoc :: I, width :: I, height :: I) p i
+iframe :: forall p i. NoninteractiveLeaf (onLoad :: I, sandbox :: I, scrolling :: I, src :: I, srcdoc :: I, width :: Size Object, height :: Size Object) p i
 iframe = unsafeCoerce E.iframe
 
-img :: forall p i. Leaf (alt :: I, crossorigin :: I, height :: I, ismap :: I, longdesc :: I, onAbort :: I, onError :: I, onLoad :: I, src :: I, usemap :: I, width :: I) p i
+img :: forall p i. Leaf (alt :: I, crossorigin :: I, height :: Size Element, ismap :: I, longdesc :: I, onAbort :: I, onError :: I, onLoad :: I, src :: I, usemap :: I, width :: Size Element) p i
 img = unsafeCoerce E.img
 
-input :: forall p i. Leaf (accept :: I, autocomplete :: I, autofocus :: I, checked :: I, disabled :: I, form :: I, formaction :: I, formenctype :: I, formmethod :: I, formnovalidate :: I, formtarget :: I, height :: I, list :: I, max :: I, min :: I, multiple :: I, onAbort :: I, onChange :: I, onError :: I, onInput :: I, onInvalid :: I, onLoad :: I, onSearch :: I, onSelect :: I, pattern :: I, placeholder :: I, readonly :: I, required :: I, size :: I, src :: I, step :: I, inputType :: I, value :: I, width :: I) p i
+input :: forall p i. Leaf (accept :: I, autocomplete :: I, autofocus :: I, checked :: I, disabled :: I, form :: I, formaction :: I, formenctype :: I, formmethod :: I, formnovalidate :: I, formtarget :: I, height :: Size Element, list :: I, max :: I, min :: I, multiple :: I, onAbort :: I, onChange :: I, onError :: I, onInput :: I, onInvalid :: I, onLoad :: I, onSearch :: I, onSelect :: I, pattern :: I, placeholder :: I, readonly :: I, required :: I, size :: I, src :: I, step :: I, inputType :: I, value :: I, width :: Size Element) p i
 input = unsafeCoerce E.input
 
 ins :: forall p i. Node (cite :: I, datetime :: I) p i
@@ -485,7 +486,7 @@ noframes = unsafeCoerce E.noframes
 noscript :: forall p i. Node () p i
 noscript = unsafeCoerce E.noscript
 
-object :: forall p i. Node (data :: I, form :: I, height :: I, onError :: I, onScroll :: I, mediaType :: I, usemap :: I, width :: I) p i
+object :: forall p i. Node (data :: I, form :: I, height :: Size Object, onError :: I, onScroll :: I, mediaType :: I, usemap :: I, width :: Size Object) p i
 object = unsafeCoerce E.object
 
 ol :: forall p i. Node (onScroll :: I, reversed :: I, start :: I, olType :: I) p i
@@ -608,7 +609,7 @@ ul = unsafeCoerce E.ul
 var :: forall p i. Node () p i
 var = unsafeCoerce E.var
 
-video :: forall p i. Node (autoplay :: I, controls :: I, height :: I, loop :: I, muted :: I, poster :: I, preload :: I, src :: I, width :: I) p i
+video :: forall p i. Node (autoplay :: I, controls :: I, height :: Size Element, loop :: I, muted :: I, poster :: I, preload :: I, src :: I, width :: Size Element) p i
 video = unsafeCoerce E.video
 
 wbr :: forall p i. Leaf () p i

--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -41,7 +41,12 @@ module Halogen.HTML.Properties
 
   , ref
 
-  , LengthLiteral(..)
+  , LengthLiteral()
+  , objectPixels
+  , objectPercent
+  , elementPixels
+  , Object()
+  , Element()
   ) where
 
 import Prelude
@@ -53,11 +58,22 @@ import DOM.HTML.Types (HTMLElement)
 
 import Halogen.HTML.Core (Prop(..), ClassName, prop, propName, attrName, runClassName)
 
-data LengthLiteral
+
+data Object -- object, iframe, and embed elements
+data Element -- any other element
+
+data LengthLiteral et
   = Pixels Int
   | Percent Number
 
-printLengthLiteral :: LengthLiteral -> String
+objectPixels :: Int -> LengthLiteral Object
+objectPixels = Pixels
+objectPercent :: Number -> LengthLiteral Object
+objectPercent = Percent
+elementPixels :: Int -> LengthLiteral Element
+elementPixels = Pixels
+
+printLengthLiteral :: forall et. LengthLiteral et -> String
 printLengthLiteral (Pixels n) = show n
 printLengthLiteral (Percent n) = show n <> "%"
 
@@ -93,7 +109,7 @@ rowSpan = prop (propName "rowSpan") (Just $ attrName "rowspan")
 for :: forall i. String -> Prop i
 for = prop (propName "htmlFor") (Just $ attrName "for")
 
-height :: forall i. LengthLiteral -> Prop i
+height :: forall i et. LengthLiteral et -> Prop i
 height = prop (propName "height") (Just $ attrName "height") <<< printLengthLiteral
 
 href :: forall i. String -> Prop i
@@ -124,7 +140,7 @@ type_ = prop (propName "type") (Just $ attrName "type")
 value :: forall i. String -> Prop i
 value = prop (propName "value") (Just $ attrName "value")
 
-width :: forall i. LengthLiteral -> Prop i
+width :: forall i et. LengthLiteral et -> Prop i
 width = prop (propName "width") (Just $ attrName "width") <<< printLengthLiteral
 
 disabled :: forall i. Boolean -> Prop i

--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -42,9 +42,8 @@ module Halogen.HTML.Properties
   , ref
 
   , LengthLiteral()
-  , objectPixels
-  , objectPercent
-  , elementPixels
+  , pixels
+  , percent
   , Object()
   , Element()
   ) where
@@ -66,12 +65,10 @@ data LengthLiteral et
   = Pixels Int
   | Percent Number
 
-objectPixels :: Int -> LengthLiteral Object
-objectPixels = Pixels
-objectPercent :: Number -> LengthLiteral Object
-objectPercent = Percent
-elementPixels :: Int -> LengthLiteral Element
-elementPixels = Pixels
+pixels :: forall a. Int -> LengthLiteral a
+pixels = Pixels
+percent :: Number -> LengthLiteral Object
+percent = Percent
 
 printLengthLiteral :: forall et. LengthLiteral et -> String
 printLengthLiteral (Pixels n) = show n

--- a/src/Halogen/HTML/Properties/Indexed.purs
+++ b/src/Halogen/HTML/Properties/Indexed.purs
@@ -4,6 +4,7 @@
 module Halogen.HTML.Properties.Indexed
   ( IProp(..)
   , I()
+  , Size()
 
   , ButtonType(..)
   , InputType(..)
@@ -94,6 +95,8 @@ newtype IProp (r :: # *) i = IProp (Prop i)
 -- | A dummy type to use in the phantom row.
 data I
 
+data Size u
+
 refine :: forall a r i. (a -> Prop i) -> a -> IProp r i
 refine = unsafeCoerce
 
@@ -127,10 +130,10 @@ rowSpan = refine P.rowSpan
 for :: forall r i. String -> IProp (for :: I | r) i
 for = refine P.for
 
-height :: forall r i. P.LengthLiteral -> IProp (height :: I | r) i
+height :: forall r i et. P.LengthLiteral et -> IProp (height :: Size et | r) i
 height = refine P.height
 
-width :: forall r i. P.LengthLiteral -> IProp (width :: I | r) i
+width :: forall r i et. P.LengthLiteral et -> IProp (width :: Size et | r) i
 width = refine P.width
 
 href :: forall r i. String -> IProp (href :: I | r) i

--- a/src/Halogen/HTML/Properties/Indexed.purs
+++ b/src/Halogen/HTML/Properties/Indexed.purs
@@ -61,8 +61,6 @@ module Halogen.HTML.Properties.Indexed
 
   , ref
 
-  , module PExport
-
   , GlobalAttributes()
   , GlobalEvents()
   , MouseEvents()
@@ -85,7 +83,6 @@ import Unsafe.Coerce (unsafeCoerce)
 import DOM.HTML.Types (HTMLElement())
 
 import Halogen.HTML.Core (Prop(), ClassName())
-import Halogen.HTML.Properties (LengthLiteral(..)) as PExport
 import Halogen.HTML.Properties as P
 
 -- | The phantom row `r` can be thought of as a context which is synthesized in the


### PR DESCRIPTION
I tried to set an img width to `Percent 100.0`, but in the DOM you'll only get back a img with width `0`

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-width

> The intrinsic width of the image in pixels. In HTML 4, either a percentage or pixels were acceptable values. In HTML5, however, only pixels are acceptable.

I was about to send a PR to remove LenghtLiteral altogether, but then I realized that object-like elements, like `object`, `embed` and `iframe` support a percent-size

This is the first time I actually used a phantom type, and I'm not sure if the names I've picked are actually good.
