### PR TITLE
Better subscription handling

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "purescript-aff": "^2.0.1",
     "purescript-const": "^2.0.0",
-    "purescript-coroutines": "^3.0.0",
+    "purescript-coroutines": "^3.1.0",
     "purescript-dom": "^3.0.0",
     "purescript-foreign": "^3.0.0",
     "purescript-free": "^3.0.0",

--- a/examples/keyboard-input/src/Main.purs
+++ b/examples/keyboard-input/src/Main.purs
@@ -7,7 +7,6 @@ import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 
 import Data.Char as CH
-import Data.Foldable (for_)
 import Data.Maybe (Maybe(..))
 import Data.String as ST
 
@@ -31,9 +30,7 @@ initialState = { chars : "", unsubscribe: Nothing }
 
 data Query a
   = Init a
-  | Append Char a
-  | Clear a
-  | Stop a
+  | HandleKey K.KeyboardEvent (Boolean -> a)
 
 type Effects eff = (dom :: DOM, avar :: AVAR, keyboard :: K.KEYBOARD | eff)
 type DSL eff = H.ComponentDSL (State eff) Query Void (Aff (Effects eff))
@@ -60,31 +57,22 @@ ui =
   eval :: Query ~> DSL eff
   eval (Init next) = do
     document <- H.liftEff $ DOM.window >>= DOM.document <#> DOM.htmlDocumentToDocument
-    { unsubscribe, eventSource } <- H.liftAff $ ES.eventSource' (K.onKeyUp document) \e ->
-      case K.readKeyboardEvent e of
-        info
-          | info.shiftKey -> do
-              K.preventDefault e
-              let char = CH.fromCharCode info.keyCode
-              pure $ Just $ H.action $ Append char
-          | info.keyCode == 13 -> do
-              K.preventDefault e
-              pure $ Just $ H.action Clear
-          | otherwise ->
-              pure Nothing
-    H.subscribe eventSource
-    H.modify (_ { unsubscribe = Just unsubscribe })
+    H.subscribe $ ES.eventSource' (K.onKeyUp document) (Just <<< H.request <<< HandleKey)
     pure next
-  eval (Append c next) = do
-    H.modify (\st -> st { chars = st.chars <> ST.singleton c })
-    pure next
-  eval (Clear next) = do
-    H.modify (_ { chars = "" })
-    eval (Stop next)
-  eval (Stop next) = do
-    unsubscribe <- H.gets _.unsubscribe
-    for_ unsubscribe \go -> H.liftAff go
-    pure next
+  eval (HandleKey e continue) =
+    case K.readKeyboardEvent e of
+      info
+        | info.shiftKey -> do
+            H.liftEff $ K.preventDefault e
+            let char = CH.fromCharCode info.keyCode
+            H.modify (\st -> st { chars = st.chars <> ST.singleton char })
+            pure (continue true)
+        | info.keyCode == 13 -> do
+            H.liftEff $ K.preventDefault e
+            H.modify (_ { chars = "" })
+            pure (continue false)
+        | otherwise ->
+            pure (continue true)
 
 main :: Eff (H.HalogenEffects (keyboard :: K.KEYBOARD)) Unit
 main = runHalogenAff do

--- a/src/Halogen/Query/EventSource.purs
+++ b/src/Halogen/Query/EventSource.purs
@@ -1,5 +1,8 @@
 module Halogen.Query.EventSource
   ( EventSource(..)
+  , unEventSource
+  , interpret
+  , hoist
   , eventSource
   , eventSource'
   , eventSource_
@@ -25,16 +28,29 @@ import Control.Monad.Free.Trans as FT
 import Control.Monad.Rec.Class (class MonadRec, tailRecM, Step(..))
 import Control.Monad.Trans.Class (lift)
 
-import Data.Either (Either(..), isLeft, isRight)
+import Data.Bifunctor (lmap)
+import Data.Either (Either(..))
 import Data.Foldable (for_)
 import Data.Maybe (Maybe)
-import Data.Newtype (class Newtype)
 
-newtype EventSource f g = EventSource (CR.Producer (f Unit) g Unit)
+newtype EventSource f m = EventSource (m { producer :: CR.Producer (f Boolean) m Unit, done :: m Unit })
 
-instance newtypeEventSource :: Newtype (EventSource f g) (FT.FreeT (CR.Emit (f Unit)) g Unit) where
-  wrap = EventSource
-  unwrap (EventSource cr) = cr
+unEventSource :: forall f m. EventSource f m -> m { producer :: CR.Producer (f Boolean) m Unit, done :: m Unit }
+unEventSource (EventSource e) = e
+
+interpret :: forall f g m. Functor m => (f ~> g) -> EventSource f m -> EventSource g m
+interpret nat (EventSource es) =
+  EventSource $
+    map
+      (\e -> { producer: FT.interpret (lmap nat) e.producer, done: e.done })
+      es
+
+hoist :: forall f m n. Functor n => (m ~> n) -> EventSource f m -> EventSource f n
+hoist nat (EventSource es) =
+  EventSource $
+    map
+      (\e -> { producer: FT.hoistFreeT nat e.producer, done: nat e.done })
+      (nat es)
 
 -- | Creates an `EventSource` for an event listener that accepts one argument.
 -- |
@@ -44,27 +60,28 @@ eventSource
   :: forall f m a eff
    . MonadAff (avar :: AVAR | eff) m
   => ((a -> Eff (avar :: AVAR | eff) Unit) -> Eff (avar :: AVAR | eff) Unit)
-  -> (a -> Eff (avar :: AVAR | eff) (Maybe (f Unit)))
+  -> (a -> Maybe (f Boolean))
   -> EventSource f m
 eventSource attach handle =
-  let producer = produce \emit -> attach (emit <<< Left <=< handle)
-  in EventSource $ FT.hoistFreeT liftAff $ catMaybes producer
+  EventSource
+    let producer = produce \emit -> attach (emit <<< Left <<< handle)
+    in pure { producer: FT.hoistFreeT liftAff $ catMaybes producer, done: pure unit }
 
 -- | Similar to `eventSource` but allows the attachment function to return an
--- | action to perform to detach the handler also. This allows the `eventSource`
--- | to be unsubscribed from.
+-- | action to perform when the handler is detached.
 eventSource'
   :: forall f m a eff
    . MonadAff (avar :: AVAR | eff) m
   => ((a -> Eff (avar :: AVAR | eff) Unit) -> Eff (avar :: AVAR | eff) (Eff (avar :: AVAR | eff) Unit))
-  -> (a -> Eff (avar :: AVAR | eff) (Maybe (f Unit)))
-  -> m { eventSource :: EventSource f m, unsubscribe :: m Unit }
+  -> (a -> Maybe (f Boolean))
+  -> EventSource f m
 eventSource' attach handle = do
-  { producer, cancel } <- liftAff $ produce' (\emit -> attach (emit <<< Left <=< handle))
-  pure
-    { eventSource: EventSource $ FT.hoistFreeT liftAff $ catMaybes producer
-    , unsubscribe: liftAff (cancel unit $> unit)
-    }
+  EventSource do
+    { producer, cancel } <- liftAff $ produce' (\emit -> attach (emit <<< Left <<< handle))
+    pure
+      { producer: FT.hoistFreeT liftAff $ catMaybes producer
+      , done: liftAff $ void $ cancel unit
+      }
 
 -- | Creates an `EventSource` for an event listener that accepts no arguments.
 -- |
@@ -74,27 +91,28 @@ eventSource_
   :: forall f m eff
    . MonadAff (avar :: AVAR | eff) m
   => (Eff (avar :: AVAR | eff) Unit -> Eff (avar :: AVAR | eff) Unit)
-  -> Eff (avar :: AVAR | eff) (Maybe (f Unit))
+  -> f Boolean
   -> EventSource f m
 eventSource_ attach handle =
-  EventSource $ FT.hoistFreeT liftAff $ catMaybes $ produce \emit ->
-    attach (emit <<< Left =<< handle)
+  EventSource
+    let producer = produce \emit -> attach $ emit (Left handle)
+    in pure { producer: FT.hoistFreeT liftAff producer, done: pure unit }
 
 -- | Similar to `eventSource_` but allows the attachment function to return an
--- | action to perform to detach the handler also. This allows the `eventSource`
--- | to be unsubscribed from.
+-- | action to perform when the handler is detached.
 eventSource_'
   :: forall f m eff
    . MonadAff (avar :: AVAR | eff) m
   => (Eff (avar :: AVAR | eff) Unit -> Eff (avar :: AVAR | eff) (Eff (avar :: AVAR | eff) Unit))
-  -> Eff (avar :: AVAR | eff) (Maybe (f Unit))
-  -> m { eventSource :: EventSource f m, unsubscribe :: m Unit }
-eventSource_' attach handle = do
-  { producer, cancel } <- liftAff $ produce' (\emit -> attach (emit <<< Left =<< handle))
-  pure
-    { eventSource: EventSource $ FT.hoistFreeT liftAff $ catMaybes producer
-    , unsubscribe: liftAff (cancel unit $> unit)
-    }
+  -> f Boolean
+  -> EventSource f m
+eventSource_' attach handle =
+  EventSource do
+    { producer, cancel } <- liftAff $ produce' \emit -> attach $ emit (Left handle)
+    pure
+      { producer: FT.hoistFreeT liftAff producer
+      , done: liftAff $ void $ cancel unit
+      }
 
 -- | Takes a producer of `Maybe`s and filters out the `Nothings`. Useful for
 -- | constructing `EventSource`s for producers that don't need to handle every
@@ -143,15 +161,14 @@ produceAff' recv = do
   inputVar <- AV.makeVar
   finalizeVar <- AV.makeVar
   let
-    pro = do
-      lift $ forkAff do
-        done <- recv $ AV.putVar inputVar
-        AV.putVar finalizeVar done
-      CR.producer do
-        out <- AV.takeVar inputVar
-        when (isRight out) do
-          AV.killVar inputVar (Exn.error "ended")
-          join $ AV.takeVar finalizeVar
-        pure out
-    cancel r = pure <<< isLeft =<< attempt (AV.putVar inputVar (Right r))
-  pure { producer: pro, cancel: cancel }
+    producer = do
+      lift $ AV.putVar finalizeVar =<< recv (AV.putVar inputVar)
+      CR.producer (AV.takeVar inputVar)
+    cancel r =
+      attempt (AV.takeVar finalizeVar) >>= case _ of
+        Left _ -> pure false
+        Right finalizer -> do
+          AV.killVar finalizeVar (Exn.error "finalized")
+          finalizer
+          pure true
+  pure { producer, cancel }

--- a/src/Halogen/Query/HalogenM.purs
+++ b/src/Halogen/Query/HalogenM.purs
@@ -8,7 +8,6 @@ import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Eff.Exception (Error)
 import Control.Monad.Fork (class MonadFork)
 import Control.Monad.Free (Free, hoistFree, liftF)
-import Control.Monad.Free.Trans (hoistFreeT, interpret)
 import Control.Monad.Reader.Class (class MonadAsk, ask)
 import Control.Monad.Rec.Class (class MonadRec, tailRecM, Step(..))
 import Control.Monad.State.Class (class MonadState)
@@ -145,8 +144,7 @@ hoistF nat (HalogenM fa) = HalogenM (hoistFree go fa)
   go = case _ of
     GetState k -> GetState k
     ModifyState f -> ModifyState f
-    Subscribe (ES.EventSource es) next ->
-      Subscribe (ES.EventSource (interpret (lmap nat) es)) next
+    Subscribe es next -> Subscribe (ES.interpret nat es) next
     Lift q -> Lift q
     Halt msg -> Halt msg
     GetSlots k -> GetSlots k
@@ -168,8 +166,7 @@ hoistM nat (HalogenM fa) = HalogenM (hoistFree go fa)
   go = case _ of
     GetState k -> GetState k
     ModifyState f -> ModifyState f
-    Subscribe (ES.EventSource es) next ->
-      Subscribe (ES.EventSource (hoistFreeT nat es)) next
+    Subscribe es next -> Subscribe (ES.hoist nat es) next
     Lift q -> Lift (nat q)
     Halt msg -> Halt msg
     GetSlots k -> GetSlots k


### PR DESCRIPTION
This works and everything, but because a process doesn't end immediately when a consumer closes (it waits for one more emit from the producer or the producer to end) this means the detach handlers might not run at all.

I have an idea that might work for a bit of a hack, if I can come up with a way of interleaving (rather than fusing) producers, but not having much luck with that so far.