### PR TITLE
Restore cheap implementation of `coeRender`

### DIFF
--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -165,7 +165,7 @@ lifecycleComponent spec =
     :: (s -> h Void (f Unit))
     -> s
     -> h (ComponentSlot h (Const Void) m Void (f Unit)) (f Unit)
-  coeRender = map (lmap absurd) -- unsafeCoerce -- ≅ map (lmap absurd id)
+  coeRender = unsafeCoerce -- ≅ map (lmap absurd)
 
 -- | A spec for a component.
 -- |


### PR DESCRIPTION
When I was tracking down the incorrect `unsafeCoerce` that turned out to be in `RenderState` this got changed and I forgot to change it back.