### PR TITLE
Add `* -> *` synonym for IProp in `Halogen`

### DIFF
--- a/src/Halogen.purs
+++ b/src/Halogen.purs
@@ -5,7 +5,7 @@
 module Halogen
   ( HalogenIO
   , HTML
-  , Prop
+  , IProp
   , module Data.Lazy
   , module Halogen.Component
   , module Halogen.HTML.Core
@@ -21,6 +21,7 @@ import Data.Lazy (defer)
 import Halogen.Component (Component, Component', ComponentDSL, ComponentHTML, ComponentSlot, ComponentSpec, LifecycleComponentSpec, ParentComponentSpec, ParentDSL, ParentHTML, ParentLifecycleComponentSpec, component, hoist, lifecycleComponent, lifecycleParentComponent, mkComponent, mkComponentSlot, parentComponent, unComponent, unComponentSlot)
 import Halogen.HTML.Core (AttrName(..), ClassName(..), Namespace(..), PropName(..), ElemName(..))
 import Halogen.HTML.Core as C
+import Halogen.HTML.Properties as P
 import Halogen.Query (Action, EventSource, HalogenF(..), HalogenM(..), RefLabel(..), Request, SubscribeStatus(..), action, checkSlot, eventSource, eventSource_, get, getHTMLElementRef, getRef, getSlots, gets, lift, liftAff, liftEff, mkQuery, modify, put, query, query', queryAll, queryAll', raise, request, subscribe)
 
 -- | A record produced when the root component in a Halogen UI has been run.
@@ -35,6 +36,6 @@ type HalogenIO f o m =
 -- | `* -> *` kinded to match the kind of a component query algebra.
 type HTML p i = C.HTML p (i Unit)
 
--- | A specialised version of the `Halogen.HTML.Core.Prop` type where `i` is
--- | `* -> *` kinded to match the kind of a component query algebra.
-type Prop i = C.Prop (i Unit)
+-- | A specialised version of the `Halogen.HTML.Properties.IProp` type where
+-- | `i` is `* -> *` kinded to match the kind of a component query algebra.
+type IProp i = P.IProp (i Unit)


### PR DESCRIPTION
Replacing the `Prop` synonym that was exported. That one isn't really useful now.