### PR TITLE
Minor docs link update

### DIFF
--- a/docs/4 - Running a component.md
+++ b/docs/4 - Running a component.md
@@ -111,7 +111,7 @@ There are also two more functions provided for cases where we want to run our Ha
 - [`awaitLoad`][Halogen.Aff.Util.awaitLoad] does what the name suggests - waits for the document to load.
 - [`selectElement`][Halogen.Aff.Util.selectElement] is a wrapper around `querySelector` - using this after `awaitLoad` allows targeting of a particular container element on the page, to embed our app within.
 
-Now we know how to build simple components and run them, we can take a look at [embedding child components within a parent](5 - Parent and child components "Parent and child components").
+Now we know how to build simple components and run them, we can take a look at [embedding child components within a parent](5 - Parent and child components.md "Parent and child components").
 
 [example-driver-routing]: ../examples/driver-routing "Routing example"
 [example-driver-websockets]: ../examples/driver-websockets "WebSockets example"


### PR DESCRIPTION
When reading through the latest docs, I noticed that the link to the 5th section of the docs wasn't working. This updates that link.