### PR TITLE
use `GetState` for H.get

### DIFF
--- a/src/Halogen/Query.purs
+++ b/src/Halogen/Query.purs
@@ -31,12 +31,12 @@ import DOM.HTML.Types (HTMLElement, readHTMLElement)
 
 import Halogen.Component.ChildPath (ChildPath, injSlot, prjSlot, injQuery, cpI)
 import Halogen.Query.EventSource (EventSource, SubscribeStatus(..), eventSource, eventSource_)
-import Halogen.Query.HalogenM (HalogenM(..), HalogenF(..), getRef, getSlots, checkSlot, mkQuery)
+import Halogen.Query.HalogenM (HalogenM(..), HalogenF(..), getRef, getSlots, checkSlot, get, gets, mkQuery)
 
 import Control.Parallel (parTraverse)
 import Control.Monad.Aff.Class (liftAff) as Exports
 import Control.Monad.Eff.Class (liftEff) as Exports
-import Control.Monad.State.Class (get, gets, modify, put) as Exports
+import Control.Monad.State.Class (modify, put) as Exports
 import Control.Monad.Trans.Class (lift) as Exports
 import Halogen.Query.InputF (RefLabel(..))
 import Halogen.Query.HalogenM (subscribe, raise) as Exports

--- a/src/Halogen/Query/HalogenM.purs
+++ b/src/Halogen/Query/HalogenM.purs
@@ -105,6 +105,12 @@ instance monadRecHalogenM :: MonadRec (HalogenM s f g p o m) where
 instance monadStateHalogenM :: MonadState s (HalogenM s f g p o m) where
   state = HalogenM <<< liftF <<< ModifyState
 
+get :: forall s f g p o m. HalogenM s f g p o m s
+get = gets id
+
+gets :: forall s f g p o m a. (s -> a) -> HalogenM s f g p o m a
+gets f = HalogenM $ liftF $ GetState f
+
 instance monadAskHalogenM :: MonadAsk r m => MonadAsk r (HalogenM s f g p o m) where
   ask = HalogenM $ liftF $ Lift $ ask
 


### PR DESCRIPTION
If I don't want to trigger a re-render of my component when querying its state, `MonadState`'s `get` shouldn't be used, because its implemented in terms of `ModifyState`.

This defines `get` and `gets` in terms of `GetState` and re-exports them instead.

I think users should also be warned somewhere not to use `get` of the `MonadState` instance if performance is important to them.

Ideally, we could define the `MonadState` instances using a separate `get` and `modify` like in Haskell, but I guess implementing `get`+`modify` or `state` is not possible in PureScript?
