### PR TITLE
Point people to the v0.12 tag in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A declarative, type-safe UI library for PureScript.
 
 :warning: The guide and template project are currently being updated for the new release. There are plenty of [examples](examples/) to dig into though.
 
+If you're working on the latest current release (0.12.0), you can check out [the v0.12.0 tag in this repo](https://github.com/slamdata/purescript-halogen/tree/v0.12.0) to see the guide and examples from that release.
+
 ## Installation
 
 ```


### PR DESCRIPTION
For people just coming to Purescript, the examples alone aren't very helpful to understanding how things work. I added a link to the latest release tag so that people can see the guide and examples from that period. I don't know when 1.0 is planning to ship, but I think this should help newcomers until then.