### PR TITLE
Implement sending messages in websockets example

### DIFF
--- a/examples/driver-websockets/src/Log.purs
+++ b/examples/driver-websockets/src/Log.purs
@@ -5,12 +5,23 @@ import Data.Array as A
 import Data.Maybe (Maybe(..))
 import Halogen as H
 import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
 
-type State = { messages :: Array String }
+type State =
+  { messages :: Array String
+  , inputText :: String
+  }
 
-data Query a = AddMessage String a
+data Query a
+  = AddMessage String a
+  | UpdateInputText String a
+  | SendMessage a
 
-component :: forall m. H.Component HH.HTML Query Unit Void m
+data Message
+  = OutputMessage String                 
+
+component :: forall m. H.Component HH.HTML Query Unit Message m
 component =
   H.component
     { initialState: const initialState
@@ -21,13 +32,35 @@ component =
   where
 
   initialState :: State
-  initialState = { messages: [] }
+  initialState = { messages: [] , inputText: "" }
 
   render :: State -> H.ComponentHTML Query
   render state =
-    HH.ol_ $ map (\msg -> HH.li_ [ HH.text msg ]) state.messages
+    HH.div_
+      [ HH.ol_ $ map (\msg -> HH.li_ [ HH.text msg ]) state.messages
+      , HH.input
+          [ HP.type_ HP.InputText
+          , HP.value (state.inputText)
+          , HE.onValueInput (HE.input UpdateInputText)
+          ]
+      , HH.button
+          [ HE.onClick (HE.input_ SendMessage) ]
+          [ HH.text "Send Message" ]
+      ]
 
-  eval :: Query ~> H.ComponentDSL State Query Void m
+  eval :: Query ~> H.ComponentDSL State Query Message m
   eval (AddMessage msg next) = do
-    H.modify \st -> { messages: st.messages `A.snoc` msg }
+    let incomingMessage = "Received: " <> msg
+    H.modify \st -> st { messages = st.messages `A.snoc` incomingMessage }
+    pure next
+  eval (SendMessage next) = do
+    st <- H.get
+    let outgoingMessage = st.inputText
+    H.raise $ OutputMessage outgoingMessage
+    H.modify \st' -> st'
+      { messages = st'.messages `A.snoc` ("Sending: " <> outgoingMessage)
+      , inputText = "" }
+    pure next              
+  eval (UpdateInputText text next) = do
+    H.modify (_ { inputText = text })
     pure next

--- a/examples/driver-websockets/src/Main.purs
+++ b/examples/driver-websockets/src/Main.purs
@@ -15,23 +15,16 @@ import Halogen.Aff as HA
 import Halogen.VDom.Driver (runUI)
 import Log as Log
 import WebSocket as WS
+import Control.Monad.Eff.Class (liftEff)
 
 -- A producer coroutine that emits messages that arrive from the websocket.
 wsProducer
   :: forall eff
-   . CR.Producer String (Aff (avar :: AVAR, err :: EXCEPTION, ws :: WS.WEBSOCKET | eff)) Unit
-wsProducer = CRA.produce \emit -> do
-  WS.Connection socket <- WS.newWebSocket (WS.URL "ws://echo.websocket.org") []
+   . WS.Connection
+  -> CR.Producer String (Aff (avar :: AVAR, err :: EXCEPTION, ws :: WS.WEBSOCKET | eff)) Unit
+wsProducer (WS.Connection socket) = CRA.produce \emit -> do
   socket.onmessage $= \event -> do
     emit $ Left $ WS.runMessage (WS.runMessageEvent event)
-
-  -- This part would be unnecessary in the real world, but since we're just
-  -- using the echo service we need to send something on init so that we have
-  -- something to receive!
-  socket.onopen $= \_ -> do
-    socket.send (WS.Message "hello")
-    socket.send (WS.Message "something")
-    socket.send (WS.Message "goodbye")
 
 -- A consumer coroutine that takes the `query` function from our component IO
 -- record and sends `AddMessage` queries in when it receives inputs from the
@@ -44,12 +37,29 @@ wsConsumer query = CR.consumer \msg -> do
   query $ H.action $ Log.AddMessage msg
   pure Nothing
 
+-- A consumer coroutine that takes output messages from our component IO
+-- and sends them using the websocket
+wsSender
+  :: forall eff
+   . WS.Connection
+  -> CR.Consumer Log.Message (Aff (HA.HalogenEffects (ws :: WS.WEBSOCKET | eff))) Unit    
+wsSender (WS.Connection socket) = CR.consumer \msg -> do
+  case msg of
+    Log.OutputMessage msgContents ->
+      liftEff $ socket.send (WS.Message msgContents)
+  pure Nothing
+                   
 main :: Eff (HA.HalogenEffects (ws :: WS.WEBSOCKET)) Unit
-main = HA.runHalogenAff do
-  body <- HA.awaitBody
-  io <- runUI Log.component unit body
+main = do
+  connection <- WS.newWebSocket (WS.URL "ws://echo.websocket.org") []
+  HA.runHalogenAff do
+    body <- HA.awaitBody
+    io <- runUI Log.component unit body
 
-  -- Connecting the consumer to the producer initializes both, opening the
-  -- websocket connection and feeding queries back to our component as messages
-  -- are received.
-  CR.runProcess (wsProducer CR.$$ wsConsumer io.query)
+    -- The wsSender consumer subscribes to all output messages
+    -- from our component
+    io.subscribe $ wsSender connection
+        
+    -- Connecting the consumer to the producer initializes both,
+    -- feeding queries back to our component as messages are received.
+    CR.runProcess (wsProducer connection CR.$$ wsConsumer io.query)


### PR DESCRIPTION
This PR implements sending messages over the websocket.

Messages to be sent are raised as output messages. The wsSender is
subscribed to these messages and sends them using the websocket.

Since we can send messages and the response is echoed, it isn't
neccessary to send the initial messages ("hello", etc.) in wsProducer.