### PR TITLE
Update effects-aff-ajax example

### DIFF
--- a/examples/effects-aff-ajax/src/Component.purs
+++ b/examples/effects-aff-ajax/src/Component.purs
@@ -34,7 +34,7 @@ ui =
 
   render :: State -> H.ComponentHTML Query
   render st =
-    HH.div_ $
+    HH.form_ $
       [ HH.h1_ [ HH.text "Lookup GitHub user" ]
       , HH.label_
           [ HH.div_ [ HH.text "Enter username:" ]


### PR DESCRIPTION
Using a form element makes interacting with the example a bit easier (hitting "enter" on the keyboard, for example).