### PR TITLE
Fix 'effects-aff-ajax' example

### DIFF
--- a/examples/effects-aff-ajax/bower.json
+++ b/examples/effects-aff-ajax/bower.json
@@ -2,7 +2,7 @@
   "name": "effects-aff-ajax",
   "private": true,
   "dependencies": {
-    "purescript-affjax": "^3.0.0",
+    "purescript-affjax": "^4.0.0",
     "purescript-halogen": "*"
   }
 }

--- a/examples/effects-aff-ajax/package.json
+++ b/examples/effects-aff-ajax/package.json
@@ -4,7 +4,7 @@
     "build": "pulp build --to dist/example.js"
   },
   "devDependencies": {
-    "pulp": "^10.0.0",
-    "purescript": "^0.10.7"
+    "pulp": "^11.0.0",
+    "purescript": "^0.11.4"
   }
 }

--- a/examples/effects-aff-ajax/src/Component.purs
+++ b/examples/effects-aff-ajax/src/Component.purs
@@ -3,6 +3,8 @@ module Component (State, Query(..), ui) where
 import Prelude
 import Control.Monad.Aff (Aff)
 import Data.Maybe (Maybe(..))
+import DOM (DOM)
+import DOM.Event.Event (Event, preventDefault)
 import Halogen as H
 import Halogen.HTML as HH
 import Halogen.HTML.Events as HE
@@ -17,9 +19,9 @@ type State =
 
 data Query a
   = SetUsername String a
-  | MakeRequest a
+  | MakeRequest Event a
 
-ui :: forall eff. H.Component HH.HTML Query Unit Void (Aff (ajax :: AX.AJAX | eff))
+ui :: forall eff. H.Component HH.HTML Query Unit Void (Aff (dom :: DOM, ajax :: AX.AJAX | eff))
 ui =
   H.component
     { initialState: const initialState
@@ -34,7 +36,8 @@ ui =
 
   render :: State -> H.ComponentHTML Query
   render st =
-    HH.form_ $
+    HH.form
+      [ HE.onSubmit (HE.input MakeRequest)]
       [ HH.h1_ [ HH.text "Lookup GitHub user" ]
       , HH.label_
           [ HH.div_ [ HH.text "Enter username:" ]
@@ -43,11 +46,11 @@ ui =
               , HE.onValueInput (HE.input SetUsername)
               ]
           ]
-      , HH.button
-          [ HP.disabled st.loading
-          , HE.onClick (HE.input_ MakeRequest)
+      , HH.input
+          [ HP.type_ HP.InputSubmit
+          , HP.value "Fetch info"
+          , HP.disabled st.loading
           ]
-          [ HH.text "Fetch info" ]
       , HH.p_
           [ HH.text (if st.loading then "Working..." else "") ]
       , HH.div_
@@ -61,12 +64,13 @@ ui =
               ]
       ]
 
-  eval :: Query ~> H.ComponentDSL State Query Void (Aff (ajax :: AX.AJAX | eff))
+  eval :: Query ~> H.ComponentDSL State Query Void (Aff (dom :: DOM, ajax :: AX.AJAX | eff))
   eval = case _ of
     SetUsername username next -> do
       H.modify (_ { username = username, result = Nothing :: Maybe String })
       pure next
-    MakeRequest next -> do
+    MakeRequest e next -> do
+      H.liftEff $ preventDefault e
       username <- H.gets _.username
       H.modify (_ { loading = true })
       response <- H.liftAff $ AX.get ("https://api.github.com/users/" <> username)

--- a/examples/effects-aff-ajax/src/Main.purs
+++ b/examples/effects-aff-ajax/src/Main.purs
@@ -2,13 +2,14 @@ module Main where
 
 import Prelude
 import Control.Monad.Eff (Eff)
+import DOM (DOM)
 import Halogen.Aff as HA
 import Halogen.VDom.Driver (runUI)
 import Network.HTTP.Affjax as AX
 import Component (ui)
 
 -- | Run the app.
-main :: Eff (HA.HalogenEffects (ajax :: AX.AJAX)) Unit
+main :: Eff (HA.HalogenEffects (dom :: DOM, ajax :: AX.AJAX)) Unit
 main = HA.runHalogenAff do
   body <- HA.awaitBody
   runUI ui unit body


### PR DESCRIPTION
Bump dependencies for this example as was done on other examples
Solves a problem with the behavior of form elements on Firefox : The submission of the form refreshes the page and thus resets everything on the page.

The solution works but may be too complex considering how early it appears in the guide, another solution would be to change the form element back to a div.