### PR TITLE
remove of the obsolete unsubscribe field

### DIFF
--- a/examples/keyboard-input/src/Main.purs
+++ b/examples/keyboard-input/src/Main.purs
@@ -23,17 +23,17 @@ import Halogen.VDom.Driver (runUI)
 
 import Keyboard as K
 
-type State eff = { chars :: String, unsubscribe :: Maybe (Aff (Effects eff) Unit) }
+type State = { chars :: String }
 
-initialState :: forall eff. State eff
-initialState = { chars : "", unsubscribe: Nothing }
+initialState :: State
+initialState = { chars : "" }
 
 data Query a
   = Init a
   | HandleKey K.KeyboardEvent (H.SubscribeStatus -> a)
 
 type Effects eff = (dom :: DOM, avar :: AVAR, keyboard :: K.KEYBOARD | eff)
-type DSL eff = H.ComponentDSL (State eff) Query Void (Aff (Effects eff))
+type DSL eff = H.ComponentDSL State Query Void (Aff (Effects eff))
 
 ui :: forall eff. H.Component HH.HTML Query Unit Void (Aff (Effects eff))
 ui =
@@ -47,7 +47,7 @@ ui =
     }
   where
 
-  render :: State eff -> H.ComponentHTML Query
+  render :: State -> H.ComponentHTML Query
   render state =
     HH.div_
       [ HH.p_ [ HH.text "Hold down the shift key and type some characters!" ]


### PR DESCRIPTION
If I understand things correctly, unsubscription is now triggered by returning `H.Done` from the keyboard handler's query, which is a much nicer solution than having to keep track of the subscription manually.

Removing the `unsubscribe` field from the example's state doesn't seem to change the example's functionality. That's why I removed it.