### PR TITLE
upgrade purescript-aff-coroutines to v6.0.0

### DIFF
--- a/examples/driver-routing/bower.json
+++ b/examples/driver-routing/bower.json
@@ -3,6 +3,6 @@
   "private": true,
   "dependencies": {
     "purescript-halogen": "*",
-    "purescript-aff-coroutines": "^5.0.0"
+    "purescript-aff-coroutines": "^6.0.0"
   }
 }

--- a/examples/driver-websockets/bower.json
+++ b/examples/driver-websockets/bower.json
@@ -3,6 +3,6 @@
   "private": true,
   "dependencies": {
     "purescript-halogen": "*",
-    "purescript-aff-coroutines": "^5.0.0"
+    "purescript-aff-coroutines": "^6.0.0"
   }
 }


### PR DESCRIPTION
As purescript-halogen has upgraded to v3.0.0 which requires
purescript-aff v4.0.0, but purescript-aff-coroutines v5.0.0 requires
purescript-aff v3.0.0.