### PR TITLE
remove `bimap id id`

### DIFF
--- a/examples/todo/src/Component/Task.purs
+++ b/examples/todo/src/Component/Task.purs
@@ -38,7 +38,7 @@ task initialState =
 
   render :: Task -> H.ComponentHTML TaskQuery
   render t =
-    bimap id id $ HH.li_
+    HH.li_
       [ HH.input
           [ HP.type_ HP.InputCheckbox
           , HP.title "Mark as completed"


### PR DESCRIPTION
`bimap id id` is same as `id` and can be removed, i guess it's leftover or something