### PR TITLE
Fix list property/attribute

### DIFF
--- a/src/Halogen/HTML/Properties.purs
+++ b/src/Halogen/HTML/Properties.purs
@@ -84,7 +84,7 @@ import DOM.HTML.Indexed.PreloadValue (PreloadValue(..)) as I
 import DOM.HTML.Indexed.StepValue (StepValue(..)) as I
 import DOM.Node.Types (Element)
 
-import Halogen.HTML.Core (class IsProp, AttrName, ClassName, Namespace, PropName(..), Prop)
+import Halogen.HTML.Core (class IsProp, AttrName(..), ClassName, Namespace, PropName(..), Prop)
 import Halogen.HTML.Core as Core
 import Halogen.Query.InputF (InputF(..), RefLabel)
 
@@ -244,7 +244,7 @@ autocomplete :: forall r i. Boolean -> IProp (autocomplete :: I.OnOff | r) i
 autocomplete = prop (PropName "autocomplete") <<< (\b -> if b then I.On else I.Off)
 
 list :: forall r i. String -> IProp (list :: String | r) i
-list = prop (PropName "list")
+list = attr (AttrName "list")
 
 autofocus :: forall r i. Boolean -> IProp (autofocus :: Boolean | r) i
 autofocus = prop (PropName "autofocus")


### PR DESCRIPTION
This makes using an input with a `list` referring to a datalist element work instead of throwing a type error due to setting a read-only property.

Unlike most properties, the list property (on an HTMLInputElement) is read-only. To set the underlying attirbute programmatically we need to use `setAttribute` instead of just setting the property. This is done for `attr`s but not `prop`s.

Not sure this is the correct fix, but it seems to work.
Thanks for the great work on Halogen!