### PR TITLE
awaitLoad canceler removes correct eventListener

### DIFF
--- a/src/Halogen/Aff/Util.purs
+++ b/src/Halogen/Aff/Util.purs
@@ -7,7 +7,7 @@ module Halogen.Aff.Util
 
 import Prelude
 
-import Control.Monad.Aff (Aff, Canceler(..), makeAff, nonCanceler, runAff_)
+import Control.Monad.Aff (Aff, effCanceler, makeAff, nonCanceler, runAff_)
 import Control.Monad.Eff (kind Effect, Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Exception (throwException, error)
@@ -36,7 +36,7 @@ awaitLoad = makeAff \callback -> liftEff do
       let listener = eventListener (\_ -> callback (Right unit))
           domContentLoaded = EventType "DOMContentLoaded"
       addEventListener domContentLoaded listener false et
-      pure $ Canceler \_ -> liftEff (removeEventListener domContentLoaded listener false et)
+      pure $ effCanceler (removeEventListener domContentLoaded listener false et)
     _ -> do
       callback (Right unit)
       pure nonCanceler

--- a/src/Halogen/Aff/Util.purs
+++ b/src/Halogen/Aff/Util.purs
@@ -18,7 +18,6 @@ import DOM.Event.EventTarget (addEventListener, eventListener, removeEventListen
 import DOM.Event.Types (EventType(..))
 import DOM.HTML (window)
 import DOM.HTML.Document (ReadyState(..), readyState)
-import DOM.HTML.Event.EventTypes (load)
 import DOM.HTML.Types (HTMLElement, windowToEventTarget, htmlDocumentToParentNode, readHTMLElement)
 import DOM.HTML.Window (document)
 import DOM.Node.ParentNode (QuerySelector(..), querySelector)
@@ -35,8 +34,9 @@ awaitLoad = makeAff \callback -> liftEff do
     Loading -> do
       et <- windowToEventTarget <$> window
       let listener = eventListener (\_ -> callback (Right unit))
-      addEventListener (EventType "DOMContentLoaded") listener false et
-      pure $ Canceler \_ -> liftEff (removeEventListener load listener false et)
+          domContentLoaded = EventType "DOMContentLoaded"
+      addEventListener domContentLoaded listener false et
+      pure $ Canceler \_ -> liftEff (removeEventListener domContentLoaded listener false et)
     _ -> do
       callback (Right unit)
       pure nonCanceler

--- a/src/Halogen/Aff/Util.purs
+++ b/src/Halogen/Aff/Util.purs
@@ -28,7 +28,7 @@ import Halogen.Aff.Effects (HalogenEffects)
 
 -- | Waits for the document to load.
 awaitLoad :: forall eff. Aff (dom :: DOM | eff) Unit
-awaitLoad = makeAff \callback -> liftEff do
+awaitLoad = makeAff \callback -> do
   rs <- readyState =<< document =<< window
   case rs of
     Loading -> do


### PR DESCRIPTION
I found a little mistake in halogen aff, `awaitLoad` Aff actions cancellation wouldn't remove eventListener correctly.
