### PR TITLE
Documentation updates for 4.0.0

### DIFF
--- a/docs/2 - Defining a component.md
+++ b/docs/2 - Defining a component.md
@@ -272,14 +272,14 @@ The resulting [`Component`][Halogen.Component.Component] can now be used [as a c
 
 Next up, let's take a look at how to create a component that can [do something effectful][handling-effects] other than update its own state.
 
-[Control.Monad.State.Class.get]: https://pursuit.purescript.org/packages/purescript-transformers/3.1.0/docs/Control.Monad.State.Class#v:get "Control.Monad.State.Class.get"
-[Control.Monad.State.Class.gets]: https://pursuit.purescript.org/packages/purescript-transformers/3.1.0/docs/Control.Monad.State.Class#v:gets "Control.Monad.State.Class.gets"
-[Control.Monad.State.Class.modify]: https://pursuit.purescript.org/packages/purescript-transformers/3.1.0/docs/Control.Monad.State.Class#v:modify "Control.Monad.State.Class.modify"
-[Control.Monad.State.Class.MonadState]: https://pursuit.purescript.org/packages/purescript-transformers/3.1.0/docs/Control.Monad.State.Class#t:MonadState "Control.Monad.State.Class.MonadState"
-[Control.Monad.State.Class.put]: https://pursuit.purescript.org/packages/purescript-transformers/3.1.0/docs/Control.Monad.State.Class#v:put "Control.Monad.State.Class.put"
-[Data.NaturalTransformation]: https://pursuit.purescript.org/packages/purescript-prelude/3.0.0/docs/Data.NaturalTransformation "Data.NaturalTransformation"
-[Data.Void.Void]: https://pursuit.purescript.org/packages/purescript-prelude/3.0.0/docs/Data.Void#t:Void "Data.Void.Void"
-[Data.Unit.Unit]: https://pursuit.purescript.org/packages/purescript-prelude/3.0.0/docs/Data.Unit#t:Unit "Data.Unit.Unit"
+[Control.Monad.State.Class.get]: https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.State.Class#v:get "Control.Monad.State.Class.get"
+[Control.Monad.State.Class.gets]: https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.State.Class#v:gets "Control.Monad.State.Class.gets"
+[Control.Monad.State.Class.modify]: https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.State.Class#v:modify "Control.Monad.State.Class.modify"
+[Control.Monad.State.Class.MonadState]: https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.State.Class#t:MonadState "Control.Monad.State.Class.MonadState"
+[Control.Monad.State.Class.put]: https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.State.Class#v:put "Control.Monad.State.Class.put"
+[Data.NaturalTransformation]: https://pursuit.purescript.org/packages/purescript-prelude/4.0.0/docs/Data.NaturalTransformation "Data.NaturalTransformation"
+[Data.Void.Void]: https://pursuit.purescript.org/packages/purescript-prelude/4.0.0/docs/Data.Void#t:Void "Data.Void.Void"
+[Data.Unit.Unit]: https://pursuit.purescript.org/packages/purescript-prelude/4.0.0/docs/Data.Unit#t:Unit "Data.Unit.Unit"
 [Halogen.Component.component-1]: https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Component#v:component "Halogen.Component.component"
 [Halogen.Component.Component]: https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Component#t:Component "Halogen.Component.Component"
 [Halogen.Component.ComponentHTML]: https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Component#t:ComponentHTML "Halogen.Component.ComponentHTML"

--- a/docs/2 - Defining a component.md
+++ b/docs/2 - Defining a component.md
@@ -177,7 +177,7 @@ We use `ComponentDSL` for components without children - it fills in some type pa
 
 - [`get`][Control.Monad.State.Class.get] retrieves the current state value
 - [`gets f`][Control.Monad.State.Class.gets] retrieves the state value and applies `f` - generally used to extract a part of the state (for example, `gets _.someProp` when using a record state).
-- [`modify f`][Control.Monad.State.Class.modify] updates the stored state value by applying `f` to it.
+- [`modify_ f`][Control.Monad.State.Class.modify_] updates the stored state value by applying `f` to it.
 - [`put`][Control.Monad.State.Class.put] overwrites the entire current state value. Be careful with this!
 
 Halogen re-exports these functions from the main `Halogen` module  for convenience.
@@ -274,7 +274,7 @@ Next up, let's take a look at how to create a component that can [do something e
 
 [Control.Monad.State.Class.get]: https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.State.Class#v:get "Control.Monad.State.Class.get"
 [Control.Monad.State.Class.gets]: https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.State.Class#v:gets "Control.Monad.State.Class.gets"
-[Control.Monad.State.Class.modify]: https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.State.Class#v:modify "Control.Monad.State.Class.modify"
+[Control.Monad.State.Class.modify_]: https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.State.Class#v:modify_ "Control.Monad.State.Class.modify_"
 [Control.Monad.State.Class.MonadState]: https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.State.Class#t:MonadState "Control.Monad.State.Class.MonadState"
 [Control.Monad.State.Class.put]: https://pursuit.purescript.org/packages/purescript-transformers/4.1.0/docs/Control.Monad.State.Class#v:put "Control.Monad.State.Class.put"
 [Data.NaturalTransformation]: https://pursuit.purescript.org/packages/purescript-prelude/4.0.0/docs/Data.NaturalTransformation "Data.NaturalTransformation"

--- a/docs/3 - Handling effects.md
+++ b/docs/3 - Handling effects.md
@@ -188,11 +188,11 @@ Let's take a look at [running a component][running-components] to produce a UI n
 
 [purescript-affjax]: https://pursuit.purescript.org/packages/purescript-affjax "purescript-affjax"
 
-[Effect.Aff.Class.liftAff]: https://pursuit.purescript.org/packages/purescript-aff/3.0.0/docs/Effect.Aff.Class#v:liftAff "Effect.Aff.Class.liftAff"
-[Effect.Aff.Class.MonadAff]: https://pursuit.purescript.org/packages/purescript-aff/3.0.0/docs/Effect.Aff.Class#t:MonadAff "Effect.Aff.Class.MonadAff"
-[Effect.Class.liftEffect]: https://pursuit.purescript.org/packages/purescript-eff/3.1.0/docs/Effect.Class#v:liftEffect "Effect.Class.liftEffect"
-[Effect.Class.MonadEffect]: https://pursuit.purescript.org/packages/purescript-eff/3.1.0/docs/Effect.Class#t:MonadEffect "Effect.Class.MonadEffect"
-[Effect.Random.random]: https://pursuit.purescript.org/packages/purescript-random/3.0.0/docs/Effect.Random#v:random "Effect.Random.random"
+[Effect.Aff.Class.liftAff]: https://pursuit.purescript.org/packages/purescript-aff/4.0.0/docs/Effect.Aff.Class#v:liftAff "Effect.Aff.Class.liftAff"
+[Effect.Aff.Class.MonadAff]: https://pursuit.purescript.org/packages/purescript-aff/4.0.0/docs/Effect.Aff.Class#t:MonadAff "Effect.Aff.Class.MonadAff"
+[Effect.Class.liftEffect]: https://pursuit.purescript.org/packages/purescript-effect/2.0.0/docs/Effect.Class#v:liftEffect "Effect.Class.liftEffect"
+[Effect.Class.MonadEffect]: https://pursuit.purescript.org/packages/purescript-effect/2.0.0/docs/Effect.Class#t:MonadEffect "Effect.Class.MonadEffect"
+[Effect.Random.random]: https://pursuit.purescript.org/packages/purescript-random/4.0.0/docs/Effect.Random#v:random "Effect.Random.random"
 [Halogen.Component.hoist]: https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Component#v:hoist "Halogen.Component.hoist"
 
 [running-components]: 4%20-%20Running%20a%20component.md "Running a component"

--- a/docs/3 - Handling effects.md
+++ b/docs/3 - Handling effects.md
@@ -154,13 +154,13 @@ ui =
   eval :: Query ~> H.ComponentDSL State Query Void Aff
   eval = case _ of
     SetUsername username next -> do
-      H.modify (_ { username = username, result = Nothing :: Maybe String })
+      H.modify_ (_ { username = username, result = Nothing :: Maybe String })
       pure next
     MakeRequest next -> do
       username <- H.gets _.username
-      H.modify (_ { loading = true })
+      H.modify_ (_ { loading = true })
       response <- H.liftAff $ AX.get ("https://api.github.com/users/" <> username)
-      H.modify (_ { loading = false, result = Just response.response })
+      H.modify_ (_ { loading = false, result = Just response.response })
       pure next
 
 ```
@@ -172,9 +172,9 @@ As with the `Effect`-based example, we've populated the `m` type variables with 
 ``` purescript
     MakeRequest next -> do
       username <- H.gets _.username
-      H.modify (_ { loading = true })
+      H.modify_ (_ { loading = true })
       response <- H.liftAff $ AX.get ("https://api.github.com/users/" <> username)
-      H.modify (_ { loading = false, result = Just response.response })
+      H.modify_ (_ { loading = false, result = Just response.response })
       pure next
 ```
 

--- a/docs/4 - Running a component.md
+++ b/docs/4 - Running a component.md
@@ -102,7 +102,7 @@ Now we know how to build simple components and run them, we can take a look at [
 [purescript-aff]: https://pursuit.purescript.org/packages/purescript-aff "purescript-aff"
 [purescript-coroutines]: https://pursuit.purescript.org/packages/purescript-coroutines "purescript-coroutines"
 
-[Control.Coroutine.consumer]: https://pursuit.purescript.org/packages/purescript-coroutines/4.0.0/docs/Control.Coroutine#v:consumer "Control.Coroutine.consumer"
+[Control.Coroutine.consumer]: https://pursuit.purescript.org/packages/purescript-coroutines/5.0.0/docs/Control.Coroutine#v:consumer "Control.Coroutine.consumer"
 [Halogen.Aff.Effects.HalogenEffects]: https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Aff.Effects#t:HalogenEffects "Halogen.Aff.Effects.HalogenEffects"
 [Halogen.Aff.Util.awaitBody]: https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Aff.Util#v:awaitBody "Halogen.Aff.Util.awaitBody"
 [Halogen.Aff.Util.awaitLoad]: https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Aff.Util#v:awaitLoad "Halogen.Aff.Util.awaitLoad"

--- a/docs/5 - Parent and child components.md
+++ b/docs/5 - Parent and child components.md
@@ -60,11 +60,11 @@ component =
   eval :: Query ~> H.ParentDSL State Query Button.Query Slot Void m
   eval = case _ of
     HandleButton (Button.Toggled _) next -> do
-      H.modify (\st -> st { toggleCount = st.toggleCount + 1 })
+      H.modify_ (\st -> st { toggleCount = st.toggleCount + 1 })
       pure next
     CheckButtonState next -> do
       buttonState <- H.query ButtonSlot $ H.request Button.IsOn
-      H.modify (_ { buttonState = buttonState })
+      H.modify_ (_ { buttonState = buttonState })
       pure next
 ```
 
@@ -196,7 +196,7 @@ In our example we use `query` to check what the current button state is when eva
 ``` purescript
 CheckButtonState next -> do
   buttonState <- H.query ButtonSlot $ H.request Button.IsOn
-  H.modify (_ { buttonState = buttonState })
+  H.modify_ (_ { buttonState = buttonState })
   pure next
 ```
 

--- a/docs/5 - Parent and child components.md
+++ b/docs/5 - Parent and child components.md
@@ -451,11 +451,11 @@ You've made it to the end of the guide, as it stands... happy Halogen-ing!
 
 [purescript-profunctor-lenses]: https://github.com/purescript-contrib/purescript-profunctor-lenses
 
-[Data.Either.Nested]: https://pursuit.purescript.org/packages/purescript-either/3.0.0/docs/Data.Either.Nested "Data.Either.Nested"
-[Data.Either.Nested.Either2]: https://pursuit.purescript.org/packages/purescript-either/3.0.0/docs/Data.Either.Nested#t:Either2 "Data.Either.Nested.Either2"
-[Data.Functor.Coproduct.Coproduct]: https://pursuit.purescript.org/packages/purescript-functors/2.0.0/docs/Data.Functor.Coproduct#t:Coproduct "Data.Functor.Coproduct.Coproduct"
-[Data.Functor.Coproduct.Nested]: https://pursuit.purescript.org/packages/purescript-functors/2.0.0/docs/Data.Functor.Coproduct.Nested "Data.Functor.Coproduct.Nested"
-[Data.Functor.Coproduct.Nested.Coproduct2]: https://pursuit.purescript.org/packages/purescript-functors/2.0.0/docs/Data.Functor.Coproduct.Nested#t:Coproduct2 "Data.Functor.Coproduct.Nested.Coproduct2"
+[Data.Either.Nested]: https://pursuit.purescript.org/packages/purescript-either/4.0.0/docs/Data.Either.Nested "Data.Either.Nested"
+[Data.Either.Nested.Either2]: https://pursuit.purescript.org/packages/purescript-either/4.0.0/docs/Data.Either.Nested#t:Either2 "Data.Either.Nested.Either2"
+[Data.Functor.Coproduct.Coproduct]: https://pursuit.purescript.org/packages/purescript-functors/3.0.0/docs/Data.Functor.Coproduct#t:Coproduct "Data.Functor.Coproduct.Coproduct"
+[Data.Functor.Coproduct.Nested]: https://pursuit.purescript.org/packages/purescript-functors/3.0.0/docs/Data.Functor.Coproduct.Nested "Data.Functor.Coproduct.Nested"
+[Data.Functor.Coproduct.Nested.Coproduct2]: https://pursuit.purescript.org/packages/purescript-functors/3.0.0/docs/Data.Functor.Coproduct.Nested#t:Coproduct2 "Data.Functor.Coproduct.Nested.Coproduct2"
 [Data.Lens.Prism.prism']: https://pursuit.purescript.org/packages/purescript-profunctor-lenses/3.2.0/docs/Data.Lens.Prism#v:prism' "Data.Lens.Prism.prism'"
 [Data.Lens.Types.Prism']: https://pursuit.purescript.org/packages/purescript-profunctor-lenses/3.2.0/docs/Data.Lens.Types#t:Prism' "Data.Lens.Types.Prism'"
 [Halogen.Component.ChildPath.ChildPath]: https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Component.ChildPath#t:ChildPath "Halogen.Component.ChildPath.ChildPath"
@@ -475,4 +475,4 @@ You've made it to the end of the guide, as it stands... happy Halogen-ing!
 [Halogen.Query.query]: https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Query#v:query "Halogen.Query.query"
 [Halogen.Query.queryAll']: https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Query#v:queryAll' "Halogen.Query.queryAll'"
 [Halogen.Query.queryAll]: https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Query#v:queryAll "Halogen.Query.queryAll"
-[Data.Void.absurd]: https://pursuit.purescript.org/packages/purescript-prelude/3.0.0/docs/Data.Void#v:absurd "Data.Void.absurd"
+[Data.Void.absurd]: https://pursuit.purescript.org/packages/purescript-prelude/4.0.0/docs/Data.Void#v:absurd "Data.Void.absurd"

--- a/examples/effects-eff-random/README.md
+++ b/examples/effects-eff-random/README.md
@@ -1,6 +1,6 @@
 ## Random number via Eff
 
-This example illustrates an Eff function being used in a component's `eval` function.
+This example illustrates an `Effect` function being used in a component's `eval` function.
 
 ### Building
 


### PR DESCRIPTION
the newest version of profunctor-lenses isn't uploaded to Pursuit yet, but it doesn't really matter, since the existing links point to pursuit documentation that is still valid.