### PR TITLE
More cleanup stuff

### DIFF
--- a/examples/higher-order-components/src/HOC.purs
+++ b/examples/higher-order-components/src/HOC.purs
@@ -47,7 +47,7 @@ factory
   => H.Component HH.HTML f i o m
   -> H.Component HH.HTML f i o m
 factory innerComponent =
-  H.component'
+  H.mkComponent
     { initialState: { on: true, input: _ }
     , render
     , eval
@@ -55,9 +55,7 @@ factory innerComponent =
 
   where
 
-  render
-    :: State i
-    -> H.ComponentHTML' (Action o) (ChildSlots f o) m
+  render :: State i -> H.ComponentHTML' (Action o) (ChildSlots f o) m
   render state =
     HH.div_
       [ HH.hr_

--- a/src/Halogen.purs
+++ b/src/Halogen.purs
@@ -18,7 +18,7 @@ import Control.Coroutine as CR
 
 import Data.Lazy (defer)
 
-import Halogen.Component (Component, ComponentSlot, ComponentSpec, ComponentSpec', component, component', hoist, mkComponentSlot, unComponent, unComponentSlot)
+import Halogen.Component (Component, ComponentSpec, ComponentSlot, ComponentSlotSpec, component, mkComponent, hoist, componentSlot, unComponent, unComponentSlot)
 import Halogen.Data.Slot (Slot)
 import Halogen.HTML (ComponentHTML, ComponentHTML')
 import Halogen.HTML.Core (AttrName(..), ClassName(..), Namespace(..), PropName(..), ElemName(..))

--- a/src/Halogen.purs
+++ b/src/Halogen.purs
@@ -4,11 +4,10 @@
 -- | conflict.
 module Halogen
   ( HalogenIO
-  , HTML
-  , IProp
   , module Data.Lazy
   , module Halogen.Data.Slot
   , module Halogen.Component
+  , module Halogen.HTML
   , module Halogen.HTML.Core
   , module Halogen.Query
   ) where
@@ -19,11 +18,10 @@ import Control.Coroutine as CR
 
 import Data.Lazy (defer)
 
-import Halogen.Component (Component, ComponentHTML, ComponentHTML', ComponentSlot, ComponentSpec, ComponentSpec', component, component', hoist, mkComponentSlot, unComponent, unComponentSlot)
+import Halogen.Component (Component, ComponentSlot, ComponentSpec, ComponentSpec', component, component', hoist, mkComponentSlot, unComponent, unComponentSlot)
 import Halogen.Data.Slot (Slot)
+import Halogen.HTML (ComponentHTML, ComponentHTML')
 import Halogen.HTML.Core (AttrName(..), ClassName(..), Namespace(..), PropName(..), ElemName(..))
-import Halogen.HTML.Core as C
-import Halogen.HTML.Properties as P
 import Halogen.Query (Action, HalogenF(..), HalogenM, HalogenM'(..), HalogenQ(..), RefLabel(..), Request, SubscriptionId, action, fork, get, getHTMLElementRef, getRef, gets, lift, liftAff, liftEffect, modify, modify_, put, query, queryAll, raise, request, subscribe, subscribe', unsubscribe)
 
 -- | A record produced when the root component in a Halogen UI has been run.
@@ -33,11 +31,3 @@ type HalogenIO f o m =
   { query :: f ~> m
   , subscribe :: CR.Consumer o m Unit -> m Unit
   }
-
--- | A specialised version of the `Halogen.HTML.Core.HTML` type where `i` is
--- | `* -> *` kinded to match the kind of a component query algebra.
-type HTML p i = C.HTML p (i Unit)
-
--- | A specialised version of the `Halogen.HTML.Properties.IProp` type where
--- | `i` is `* -> *` kinded to match the kind of a component query algebra.
-type IProp r i = P.IProp r (i Unit)

--- a/src/Halogen/Aff/Driver.purs
+++ b/src/Halogen/Aff/Driver.purs
@@ -187,7 +187,7 @@ runUI renderSpec component i = do
       handler :: Input act -> Aff Unit
       handler = Eval.queueOrRun ds.pendingHandlers <<< void <<< Eval.evalF render ds.selfRef
       childHandler :: act -> Aff Unit
-      childHandler = Eval.queueOrRun ds.pendingQueries <<< handler <<< Query
+      childHandler = Eval.queueOrRun ds.pendingQueries <<< handler <<< Action
     rendering <-
       renderSpec.render
         (handleAff <<< handler)

--- a/src/Halogen/Aff/Driver.purs
+++ b/src/Halogen/Aff/Driver.purs
@@ -27,7 +27,7 @@ import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import Halogen (HalogenIO)
 import Halogen.Aff.Driver.Eval as Eval
-import Halogen.Aff.Driver.State (DriverState(..), DriverStateRef(..), DriverStateX, LifecycleHandlers, RenderStateX, initDriverState, renderStateX, renderStateX_, unDriverStateX)
+import Halogen.Aff.Driver.State (DriverState(..), DriverStateRef(..), DriverStateX, LifecycleHandlers, RenderStateX, initDriverState, mapDriverState, renderStateX, renderStateX_, unDriverStateX)
 import Halogen.Component (Component, ComponentSlot, unComponent, unComponentSlot)
 import Halogen.Data.Slot as Slot
 import Halogen.Query.EventSource as ES
@@ -50,10 +50,9 @@ import Halogen.Query.Input (Input(..))
 -- | The "inner" type variables, used by `r` and the other functions are as
 -- | follows:
 -- | - `s` is the state type for the component.
--- | - `f` is the query algebra for the component.
--- | - `g` is the query algebra for the component's children.
--- | - `p` is the slot address value type.
--- | - `o` is the output message type for the component.
+-- | - `act` is the action type for the component
+-- | - `ps` is the set of slots for addressing child components
+-- | - `o` is the output message type for the component
 -- |
 -- | Note that none of these variables can escape `RenderSpec`'s functions. They
 -- | need to be instantiated with each function call, as the same `RenderSpec`
@@ -82,7 +81,7 @@ import Halogen.Query.Input (Input(..))
 -- | driver render state for a component and produce a new one that may remap
 -- | the rendered value to be something more suitable for grafting during
 -- | `render` of the parent. For the built-in `halogen-vdom` driver this is
--- | just `id`. For the `virtual-dom` driver it wraps the rendered HTML
+-- | just `identity`. For the `virtual-dom` driver it wraps the rendered HTML
 -- | in a widget, to prevent the `virtual-dom` algorithm from re-diffing
 -- | values that we know are unchanged.
 -- |
@@ -102,9 +101,6 @@ type RenderSpec h r =
   , renderChild :: forall s act ps o. r s act ps o -> r s act ps o
   , removeChild :: forall s act ps o. r s act ps o -> Effect Unit
   }
-
-newLifecycleHandlers :: Effect (Ref LifecycleHandlers)
-newLifecycleHandlers = Ref.new { initializers: L.Nil, finalizers: L.Nil }
 
 runUI
   :: forall h r f i o
@@ -134,10 +130,7 @@ runUI renderSpec component i = do
     ~> Aff
   evalDriver ref = Eval.evalQ render ref
 
-  rootHandler
-    :: Ref (M.Map Int (AV.AVar o))
-    -> o
-    -> Aff Unit
+  rootHandler :: Ref (M.Map Int (AV.AVar o)) -> o -> Aff Unit
   rootHandler ref message = do
     listeners <- liftEffect $ Ref.read ref
     traverse_ fork $ map (AV.put message) listeners
@@ -192,9 +185,9 @@ runUI renderSpec component i = do
     Ref.write ds.children ds.childrenIn
     let
       handler :: Input act -> Aff Unit
-      handler = Eval.queuingHandler (void <<< Eval.evalF render ds.selfRef) ds.pendingHandlers
+      handler = Eval.queueOrRun ds.pendingHandlers <<< void <<< Eval.evalF render ds.selfRef
       childHandler :: act -> Aff Unit
-      childHandler = Eval.queuingHandler (handler <<< Query) ds.pendingQueries
+      childHandler = Eval.queueOrRun ds.pendingQueries <<< handler <<< Query
     rendering <-
       renderSpec.render
         (handleAff <<< handler)
@@ -207,11 +200,8 @@ runUI renderSpec component i = do
       childDS <- Ref.read childVar
       renderStateX_ renderSpec.removeChild childDS
       finalize lchs childDS
-    Ref.modify_ (\(DriverState ds') ->
-      DriverState ds'
-        { rendering = Just rendering
-        , children = children
-        }) ds.selfRef
+    flip Ref.modify_ ds.selfRef $ mapDriverState \ds' ->
+      ds' { rendering = Just rendering, children = children }
     when shouldProcessHandlers do
       flip tailRecM unit \_ -> do
         handlers <- Ref.read ds.pendingHandlers
@@ -275,22 +265,6 @@ runUI renderSpec component i = do
         }) lchs
       pure unit
 
-  handlePending
-    :: Ref (Maybe (L.List (Aff Unit)))
-    -> Effect Unit
-  handlePending ref = do
-    queue <- Ref.read ref
-    Ref.write Nothing ref
-    for_ queue (handleAff <<< traverse_ fork <<< L.reverse)
-
-  cleanupSubscriptions
-    :: forall s f' act ps i' o'
-     . DriverState h r s f' act ps i' o'
-    -> Effect Unit
-  cleanupSubscriptions (DriverState ds) = do
-    traverse_ (handleAff <<< traverse_ (fork <<< ES.finalize)) =<< Ref.read ds.subscriptions
-    Ref.write Nothing ds.subscriptions
-
   finalize
     :: forall f' o'
      . Ref LifecycleHandlers
@@ -308,11 +282,24 @@ runUI renderSpec component i = do
         dsx <- Ref.read ref
         finalize lchs dsx
 
--- | TODO: we could do something more intelligent now this isn't baked into the
--- | virtual-dom rendering. Perhaps write to an avar when an error occurs...
--- | something other than a runtime exception anyway.
-handleAff
-  :: forall a
-   . Aff a
+newLifecycleHandlers :: Effect (Ref LifecycleHandlers)
+newLifecycleHandlers = Ref.new { initializers: L.Nil, finalizers: L.Nil }
+
+handlePending :: Ref (Maybe (L.List (Aff Unit))) -> Effect Unit
+handlePending ref = do
+  queue <- Ref.read ref
+  Ref.write Nothing ref
+  for_ queue (handleAff <<< traverse_ fork <<< L.reverse)
+
+cleanupSubscriptions
+  :: forall h r s f act ps i o
+   . DriverState h r s f act ps i o
   -> Effect Unit
+cleanupSubscriptions (DriverState ds) = do
+  traverse_ (handleAff <<< traverse_ (fork <<< ES.finalize)) =<< Ref.read ds.subscriptions
+  Ref.write Nothing ds.subscriptions
+
+-- We could perhaps do something more intelligent now this isn't baked into
+-- the virtual-dom rendering. It hasn't really been a problem so far though.
+handleAff :: forall a. Aff a -> Effect Unit
 handleAff = runAff_ (either throwException (const (pure unit)))

--- a/src/Halogen/Aff/Driver/Eval.purs
+++ b/src/Halogen/Aff/Driver/Eval.purs
@@ -50,7 +50,7 @@ evalF render ref = case _ of
   RefUpdate (RefLabel p) el -> do
     liftEffect $ flip Ref.modify_ ref $ mapDriverState \st ->
       st { refs = M.alter (const el) p st.refs }
-  Query act -> do
+  Action act -> do
     DriverState st <- liftEffect (Ref.read ref)
     evalM render ref (st.component.eval (Handle act unit))
 
@@ -103,7 +103,7 @@ evalM render initRef (HalogenM hm) = foldFree (go initRef) hm
             act <- CR.await
             subs <- lift $ liftEffect (Ref.read subscriptions)
             when ((M.member sid <$> subs) == Just true) do
-              _ <- lift $ fork $ evalF render ref (Query act)
+              _ <- lift $ fork $ evalF render ref (Action act)
               consumer
         liftEffect $ Ref.modify_ (map (M.insert sid done)) subscriptions
         CR.runProcess (consumer `CR.pullFrom` producer)

--- a/src/Halogen/Aff/Driver/Eval.purs
+++ b/src/Halogen/Aff/Driver/Eval.purs
@@ -27,9 +27,10 @@ import Effect.Class (liftEffect)
 import Effect.Ref (Ref)
 import Effect.Ref as Ref
 import Halogen.Aff.Driver.State (DriverState(..), DriverStateRef(..), LifecycleHandlers, mapDriverState, unDriverStateX)
+import Halogen.Query.ChildQuery as CQ
 import Halogen.Query.EventSource as ES
 import Halogen.Query.ForkF as FF
-import Halogen.Query.HalogenM (HalogenAp(..), HalogenF(..), HalogenM'(..), ChildQuery, UnpackQuery(..), SubscriptionId(..), unChildQuery)
+import Halogen.Query.HalogenM (HalogenAp(..), HalogenF(..), HalogenM'(..), SubscriptionId(..))
 import Halogen.Query.HalogenQ (HalogenQ(..))
 import Halogen.Query.Input (Input(..), RefLabel(..))
 import Unsafe.Reference (unsafeRefEq)
@@ -134,11 +135,11 @@ evalM render initRef (HalogenM hm) = foldFree (go initRef) hm
   evalChildQuery
     :: forall s' f' act' ps' i' o' a'
      . Ref (DriverState h r s' f' act' ps' i' o')
-    -> ChildQuery ps' a'
+    -> CQ.ChildQueryBox ps' a'
     -> Aff a'
   evalChildQuery ref cqb = do
     DriverState st <- liftEffect (Ref.read ref)
-    unChildQuery (\{ unpack: UnpackQuery unpack, query, reply } -> do
+    CQ.unChildQueryBox (\(CQ.ChildQuery unpack query reply) -> do
       let
         evalChild (DriverStateRef var) = parallel do
           dsx <- liftEffect (Ref.read var)

--- a/src/Halogen/Aff/Driver/State.purs
+++ b/src/Halogen/Aff/Driver/State.purs
@@ -37,19 +37,6 @@ type LifecycleHandlers =
   , finalizers :: List (Aff Unit)
   }
 
--- | The type used to track a driver's persistent state.
--- |
--- | - `h` is the type of value the components produce for rendering.
--- | - `r` is the type for the render state for the driver.
--- | - `s` is the component state type.
--- | - `f` is the projected component query algebra - used for multi-child-type
--- |       components, by projecting to `z` we can avoid the need to remap the
--- |       entire component.
--- | - `z` is the unprojected component query algebra.
--- | - `g` is the component child query algebra.
--- | - `p` is the type of slots for the component.
--- | - `i` is the invput value type.
--- | - `o` is the type of output messages from the component.
 newtype DriverState h r s f act ps i o = DriverState (DriverStateRec h r s f act ps i o)
 
 type DriverStateRec h r s f act ps i o =

--- a/src/Halogen/Aff/Driver/State.purs
+++ b/src/Halogen/Aff/Driver/State.purs
@@ -1,6 +1,7 @@
 module Halogen.Aff.Driver.State
   ( LifecycleHandlers
   , DriverState(..)
+  , mapDriverState
   , DriverStateRef(..)
   , DriverStateRec
   , DriverStateX
@@ -68,6 +69,13 @@ type DriverStateRec h r s f act ps i o =
   , subscriptions :: Ref (Maybe (M.Map SubscriptionId (Finalizer Aff)))
   , lifecycleHandlers :: Ref LifecycleHandlers
   }
+
+mapDriverState
+  :: forall h r s f act ps i o
+  . (DriverStateRec h r s f act ps i o -> DriverStateRec h r s f act ps i o)
+  -> DriverState h r s f act ps i o
+  -> DriverState h r s f act ps i o
+mapDriverState f (DriverState ds) = DriverState (f ds)
 
 newtype DriverStateRef h r f o = DriverStateRef (Ref (DriverStateX h r f o))
 

--- a/src/Halogen/Aff/Driver/State.purs
+++ b/src/Halogen/Aff/Driver/State.purs
@@ -24,7 +24,7 @@ import Effect (Effect)
 import Effect.Aff (Aff)
 import Effect.Ref (Ref)
 import Effect.Ref as Ref
-import Halogen.Component (ComponentSpec')
+import Halogen.Component (ComponentSpec)
 import Halogen.Data.Slot (SlotStorage)
 import Halogen.Data.Slot as SlotStorage
 import Halogen.Query.EventSource (Finalizer)
@@ -53,7 +53,7 @@ type LifecycleHandlers =
 newtype DriverState h r s f act ps i o = DriverState (DriverStateRec h r s f act ps i o)
 
 type DriverStateRec h r s f act ps i o =
-  { component :: ComponentSpec' h s f act ps i o Aff
+  { component :: ComponentSpec h s f act ps i o Aff
   , state :: s
   , refs :: M.Map String Element
   , children :: SlotStorage ps (DriverStateRef h r)
@@ -136,7 +136,7 @@ renderStateX_ f = unDriverStateX \st -> traverse_ f st.rendering
 
 initDriverState
   :: forall h r s f act ps i o
-   . ComponentSpec' h s f act ps i o Aff
+   . ComponentSpec h s f act ps i o Aff
   -> i
   -> (o -> Aff Unit)
   -> Ref LifecycleHandlers

--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -1,15 +1,15 @@
 module Halogen.Component
   ( Component
-  , ComponentSpec
+  , ComponentArgs
   , component
-  , ComponentSpec'
-  , component'
+  , ComponentSpec
+  , mkComponent
   , unComponent
   , hoist
-  , ComponentSlot'
   , ComponentSlot
+  , componentSlot
+  , ComponentSlotSpec
   , mkComponentSlot
-  , mkComponentSlot'
   , unComponentSlot
   , hoistSlot
   ) where
@@ -35,22 +35,47 @@ import Unsafe.Coerce (unsafeCoerce)
 -- | - `h` is the type that will be rendered by the component, usually `HTML`
 -- | - `f` is the query algebra; the requests that can be made of the component
 -- | - `i` is the input value that will be received when the parent of
--- |       this component renders
+-- |   this component renders
 -- | - `o` is the type of messages the component can raise
 -- | - `m` is the effect monad used during evaluation
 data Component (h :: Type -> Type -> Type) (f :: Type -> Type) i o (m :: Type -> Type)
 
--- | The spec for a component.
+-- | The argument record for the `component` function.
 -- |
+-- | The type variables involved:
 -- | - `h` is the type that will be rendered by the component, usually `HTML`
 -- | - `s` is the component's state
 -- | - `f` is the query algebra; the requests that can be made of the component
 -- | - `ps` is the set of slots for addressing child components
 -- | - `i` is the input value that will be received when the parent of
--- |       this component renders
+-- |    this component renders
 -- | - `o` is the type of messages the component can raise
 -- | - `m` is the effect monad used during evaluation
-type ComponentSpec h s f ps i o m =
+-- |
+-- | The values in the record:
+-- | - `initialState` is a function that accepts an input value and produces the
+-- |   state the component will start with. If the input value is unused
+-- |   (`Unit`), or irrelevant to the state construction, this will often be
+-- |   `const ?someInitialStateValue`.
+-- | - `render` is a function that accepts the component's current state and
+-- |   produces a value to render (`HTML` usually). The rendered output can
+-- |   raise `f Unit` queries that the component will evaluate.
+-- | - `eval` handles runing queries to change the state of the component, or
+-- |   perform some effect, or return some information about the component's
+-- |   state.
+-- | - `receiever` is a function that maps an input value to a query. Every time
+-- |   the input value changes this query will be passed through to `eval`.
+-- |   `const Nothing` can be used here if no action needs to be taken.
+-- | - `initializer` specifies an optional action-style query to raise on the
+-- |   component when it is first constructed. This allows the component to
+-- |   perfom effects that may be necessary to set up the component.
+-- | - `finalizer` specifies an optional action-style query to raise on the
+-- |   component when it is being removed. This allows the component to perfom
+-- |   effects that may be necessary to clean up after the component. This is
+-- |   not commonly necessary - subscriptions are automatically ended internally
+-- |   by Halogen, it's only required for components that manipulate resources
+-- |   outside of Halogen's reach.
+type ComponentArgs h s f ps i o m =
   { initialState :: i -> s
   , render :: s -> h (ComponentSlot h ps m (f Unit)) (f Unit)
   , eval :: f ~> HalogenM' s (f Unit) ps o m
@@ -59,14 +84,15 @@ type ComponentSpec h s f ps i o m =
   , finalizer :: Maybe (f Unit)
   }
 
--- | Builds a component from a `ComponentSpec`.
+-- | Builds a [`Component`](#t:Component) from a [`ComponentArgs`](#t:ComponentArgs)
+-- | record.
 component
   :: forall h s f ps i o m
-   . ComponentSpec h s f ps i o m
+   . ComponentArgs h s f ps i o m
   -> Component h f i o m
-component = component' <<< go
+component = mkComponent <<< go
   where
-    go :: ComponentSpec h s f ps i o m -> ComponentSpec' h s f (f Unit) ps i o m
+    go :: ComponentArgs h s f ps i o m -> ComponentSpec h s f (f Unit) ps i o m
     go spec =
       { initialState: spec.initialState
       , render: spec.render
@@ -78,7 +104,10 @@ component = component' <<< go
           Request fa -> spec.eval fa
       }
 
--- | An alternative formulation of the spec for a component.
+-- | The spec for a component. This differs from [`ComponentArgs`](#t:ComponentArgs)
+-- | as it is the representation used by Halogen - the [`component`](#v:component)
+-- | function translates a [`ComponentArgs`](#t:ComponentArgs) record into a
+-- | `ComponentSpec`.
 -- |
 -- | Instead of accepting a number of properties that map things to queries,
 -- | these cases are instead handled by pattern matching on a `HalogenQ` algebra
@@ -90,42 +119,57 @@ component = component' <<< go
 -- | case the query algebra must also contain the actions the component can
 -- | raise internally.
 -- |
+-- | The type variables involved:
 -- | - `h` is the type that will be rendered by the component, usually `HTML`
 -- | - `s` is the component's state
 -- | - `f` is the query algebra; the requests that can be made of the component
 -- | - `act` is the type of actions; messages internal to the component that
--- |         can be evaluated
+-- |   can be evaluated
 -- | - `ps` is the set of slots for addressing child components
 -- | - `i` is the input value that will be received when the parent of
--- |       this component renders
+-- |   this component renders
 -- | - `o` is the type of messages the component can raise
 -- | - `m` is the effect monad used during evaluation
-type ComponentSpec' h s f act ps i o m =
+-- |
+-- | The values in the record:
+-- | - `initialState` is a function that accepts an input value and produces the
+-- |   state the component will start with. If the input value is unused
+-- |   (`Unit`), or irrelevant to the state construction, this will often be
+-- |   `const ?someInitialStateValue`.
+-- | - `render` is a function that accepts the component's current state and
+-- |   produces a value to render (`HTML` usually). The rendered output can
+-- |   raise actions that will be handled in `eval`.
+-- | - `eval` is a function that handles the `HalogenQ` algebra that deals with
+-- |   component lifecycle, handling actions, and responding to requests.
+type ComponentSpec h s f act ps i o m =
   { initialState :: i -> s
   , render :: s -> h (ComponentSlot h ps m act) act
   , eval :: HalogenQ f act i ~> HalogenM' s act ps o m
   }
 
--- | Builds a component from a `ComponentSpec'`.
-component'
-  :: forall h s f g ps i o m
-   . ComponentSpec' h s f g ps i o m
+-- | Constructs a [`Component`](#t:Component) from a [`ComponentSpec`](#t:ComponentSpec).
+mkComponent
+  :: forall h s f act ps i o m
+   . ComponentSpec h s f act ps i o m
   -> Component h f i o m
-component' = unsafeCoerce
+mkComponent = unsafeCoerce
 
--- | Exposes the inner details of a component to a function to produce a new
--- | result. The hidden details will not be allowed to be revealed in the result
--- | of the function - the compiler will complain about an escaped skolem if
--- | this is attempted.
+-- | Exposes the inner details of a [`Component`](#t:Component) to a function
+-- | to produce a new result.
+-- |
+-- | The hidden details will not be allowed to be revealed in the result
+-- | of the function - if any of the hidden types (state, action, set of slots)
+-- | appear in the result, the compiler will complain about an escaped skolem.
 unComponent
   :: forall h f i o m r
-   . (forall s act ps. ComponentSpec' h s f act ps i o m -> r)
+   . (forall s act ps. ComponentSpec h s f act ps i o m -> r)
   -> Component h f i o m
   -> r
 unComponent = unsafeCoerce
 
--- | Changes the component's `m` type. A use case for this would be to interpret
--- | some `Free` monad as `Aff` so the component can be used with `runUI`.
+-- | Changes the [`Component`](#t:Component)'s `m` type. A use case for this
+-- | might be to interpret some `Free` monad as `Aff` so the component can be
+-- | used with `runUI`.
 hoist
   :: forall h f i o m m'
    . Bifunctor h
@@ -134,30 +178,29 @@ hoist
   -> Component h f i o m
   -> Component h f i o m'
 hoist nat = unComponent \c ->
-  component'
+  mkComponent
     { initialState: c.initialState
     , render: lmap (hoistSlot nat) <<< c.render
     , eval: HM.hoist nat <<< c.eval
     }
 
---------------------------------------------------------------------------------
-
-type ComponentSlot' h f i o ps m a =
-  { get :: forall slot. SlotStorage ps slot -> Maybe (slot f o)
-  , pop :: forall slot. SlotStorage ps slot -> Maybe (Tuple (slot f o) (SlotStorage ps slot))
-  , set :: forall slot. slot f o -> SlotStorage ps slot -> SlotStorage ps slot
-  , component :: Component h f i o m
-  , input :: forall act. HalogenQ f act i Unit
-  , output :: o -> Maybe a
-  }
-
+-- | A slot for a child component in a component's rendered content.
 data ComponentSlot (h :: Type -> Type -> Type) (ps :: # Type) (m :: Type -> Type) a
 
 instance functorComponentSlot :: Functor (ComponentSlot h ps m) where
-  map f = unComponentSlot \slot -> mkComponentSlot' $ slot { output = map f <$> slot.output }
+  map f = unComponentSlot \slot ->
+    mkComponentSlot $ slot { output = map f <$> slot.output }
 
-mkComponentSlot
-  :: forall h sym px ps f i o p m a
+-- | Constructs a [`ComponentSlot`](#t:ComponentSlot).
+-- |
+-- | Takes:
+-- | - the slot address label
+-- | - the slot address index
+-- | - the component for the slot
+-- | - the input value to pass to the component
+-- | - a function mapping outputs from the component to a query in the parent
+componentSlot
+  :: forall h sym px ps f i o p m act
    . Row.Cons sym (Slot f o p) px ps
   => IsSymbol sym
   => Ord p
@@ -165,39 +208,55 @@ mkComponentSlot
   -> p
   -> Component h f i o m
   -> i
-  -> (o -> Maybe a)
-  -> ComponentSlot h ps m a
-mkComponentSlot sym p comp input output =
-  mkComponentSlot' { get, pop, set, component: comp, input: Receive input unit, output }
-  where
-  get :: forall slot. SlotStorage ps slot -> Maybe (slot f o)
-  get = Slot.lookup sym p
+  -> (o -> Maybe act)
+  -> ComponentSlot h ps m act
+componentSlot sym p comp input output =
+  mkComponentSlot
+    { get: Slot.lookup sym p
+    , pop: Slot.pop sym p
+    , set: Slot.insert sym p
+    , component: comp
+    , input: Receive input unit
+    , output
+    }
 
-  pop :: forall slot. SlotStorage ps slot -> Maybe (Tuple (slot f o) (SlotStorage ps slot))
-  pop = Slot.pop sym p
+-- | The internal representation used for a [`ComponentSlot`](#t:ComponentSlot).
+type ComponentSlotSpec h f i o ps m act =
+  { get :: forall slot. SlotStorage ps slot -> Maybe (slot f o)
+  , pop :: forall slot. SlotStorage ps slot -> Maybe (Tuple (slot f o) (SlotStorage ps slot))
+  , set :: forall slot. slot f o -> SlotStorage ps slot -> SlotStorage ps slot
+  , component :: Component h f i o m
+  , input :: forall a. HalogenQ f a i Unit
+  , output :: o -> Maybe act
+  }
 
-  set :: forall slot. slot f o -> SlotStorage ps slot -> SlotStorage ps slot
-  set = Slot.insert sym p
+-- | Constructs [`ComponentSlot`](#t:ComponentSlot) from a [`ComponentSlotSpec`](#t:ComponentSlotSpec).
+mkComponentSlot
+  :: forall h f i o ps m act
+   . ComponentSlotSpec h f i o ps m act
+  -> ComponentSlot h ps m act
+mkComponentSlot = unsafeCoerce
 
-mkComponentSlot'
-  :: forall h f i o ps m a
-   . ComponentSlot' h f i o ps m a
-  -> ComponentSlot h ps m a
-mkComponentSlot' = unsafeCoerce
-
+-- | Exposes the inner details of a [`ComponentSlot`](#t:ComponentSlot) to a
+-- | function to produce a new result.
+-- |
+-- | The hidden details will not be allowed to be revealed in the result
+-- | of the function - if any of the hidden types (state, action, set of slots)
+-- | appear in the result, the compiler will complain about an escaped skolem.
 unComponentSlot
-  :: forall h ps m a r
-   . (forall f i o. ComponentSlot' h f i o ps m a -> r)
-  -> ComponentSlot h ps m a
+  :: forall h ps m act r
+   . (forall f i o. ComponentSlotSpec h f i o ps m act -> r)
+  -> ComponentSlot h ps m act
   -> r
 unComponentSlot = unsafeCoerce
 
+-- | Changes the [`ComponentSlot`](#t:ComponentSlot)'s `m` type.
 hoistSlot
-  :: forall h m m' ps a
+  :: forall h m m' ps act
    . Bifunctor h
   => Functor m'
   => (m ~> m')
-  -> ComponentSlot h ps m a
-  -> ComponentSlot h ps m' a
+  -> ComponentSlot h ps m act
+  -> ComponentSlot h ps m' act
 hoistSlot nat = unComponentSlot \slot ->
-  mkComponentSlot' $ slot { component = hoist nat slot.component }
+  mkComponentSlot $ slot { component = hoist nat slot.component }

--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -2,8 +2,6 @@ module Halogen.Component
   ( Component
   , ComponentSpec'
   , ComponentSpec
-  , ComponentHTML'
-  , ComponentHTML
   , component'
   , component
   , unComponent
@@ -25,7 +23,6 @@ import Data.Symbol (class IsSymbol, SProxy)
 import Data.Tuple (Tuple)
 import Halogen.Data.Slot (Slot, SlotStorage)
 import Halogen.Data.Slot as Slot
-import Halogen.HTML.Core (HTML)
 import Halogen.Query.HalogenM (HalogenM')
 import Halogen.Query.HalogenM as HM
 import Halogen.Query.HalogenQ (HalogenQ(..))
@@ -92,12 +89,6 @@ specToSpec spec =
       Handle fa a -> spec.eval fa $> a
       Request fa -> spec.eval fa
   }
-
-type ComponentHTML' act ps m = HTML (ComponentSlot HTML ps m act) act
-
--- | A convenience synonym for the output type of a `render` function, for a
--- | component that renders HTML.
-type ComponentHTML f ps m = ComponentHTML' (f Unit) ps m
 
 component'
   :: forall h s f g ps i o m

--- a/src/Halogen/Component/Profunctor.purs
+++ b/src/Halogen/Component/Profunctor.purs
@@ -5,7 +5,7 @@ import Prelude
 import Data.Bifunctor (lmap)
 import Data.Newtype (class Newtype)
 import Data.Profunctor (class Profunctor, dimap)
-import Halogen.Component (Component, ComponentSpec', component', unComponent)
+import Halogen.Component (Component, ComponentSpec, mkComponent, unComponent)
 import Halogen.Query.HalogenM as HM
 
 newtype ProComponent h f m i o = ProComponent (Component h f i o m)
@@ -14,15 +14,15 @@ derive instance newtypeProComponent :: Newtype (ProComponent h f m i o) _
 
 instance profunctorProComponent :: Functor f => Profunctor (ProComponent h f m) where
   dimap f g (ProComponent c) =
-    ProComponent (unComponent (component' <<< dimapSpec f g) c)
+    ProComponent (unComponent (mkComponent <<< dimapSpec f g) c)
 
 dimapSpec
   :: forall h s f act ps i j o p m
    . Functor f
   => (j -> i)
   -> (o -> p)
-  -> ComponentSpec' h s f act ps i o m
-  -> ComponentSpec' h s f act ps j p m
+  -> ComponentSpec h s f act ps i o m
+  -> ComponentSpec h s f act ps j p m
 dimapSpec f g spec =
   { initialState: spec.initialState <<< f
   , render: spec.render

--- a/src/Halogen/HTML.purs
+++ b/src/Halogen/HTML.purs
@@ -24,11 +24,18 @@ import Prelude (class Ord, Unit, Void)
 import Prim.Row as Row
 import Unsafe.Coerce (unsafeCoerce)
 
-type ComponentHTML' act ps m = HTML (ComponentSlot HTML ps m act) act
+-- | A convenience synonym for the output type of a `render` function, for a
+-- | component that renders HTML, for a component constructed with the
+-- | `component` smart constructor.
+type ComponentHTML f ps m = ComponentHTML' (f Unit) ps m
 
 -- | A convenience synonym for the output type of a `render` function, for a
 -- | component that renders HTML.
-type ComponentHTML f ps m = ComponentHTML' (f Unit) ps m
+-- |
+-- | This type is more flexible than `ComponentHTML` as it allows for
+-- | non-query-algebra actions to be raised from the HTML (kind `Type` rather
+-- | than `Type -> Type`).
+type ComponentHTML' act ps m = HTML (ComponentSlot HTML ps m act) act
 
 -- | A type useful for a chunk of HTML with no slot-embedding or query-raising.
 -- |

--- a/src/Halogen/HTML.purs
+++ b/src/Halogen/HTML.purs
@@ -49,13 +49,13 @@ fromPlainHTML = unsafeCoerce -- ≅ bimap absurd absurd
 -- | - the input value to pass to the component
 -- | - a function mapping outputs from the component to a query in the parent
 slot
-  :: forall sym px ps g i o p m act
-   . Row.Cons sym (Slot g o p) px ps
+  :: forall sym px ps f i o p m act
+   . Row.Cons sym (Slot f o p) px ps
   => IsSymbol sym
   => Ord p
   => SProxy sym
   -> p
-  -> Component HTML g i o m
+  -> Component HTML f i o m
   -> i
   -> (o -> Maybe act)
   -> ComponentHTML' act ps m

--- a/src/Halogen/HTML.purs
+++ b/src/Halogen/HTML.purs
@@ -1,7 +1,9 @@
 -- | This module re-exports the types for the `HTML` DSL, and values for all
 -- | supported HTML elements.
 module Halogen.HTML
-  ( PlainHTML
+  ( ComponentHTML'
+  , ComponentHTML
+  , PlainHTML
   , fromPlainHTML
   , slot
   , module Halogen.HTML.Core
@@ -13,14 +15,20 @@ import Halogen.HTML.Elements
 
 import Data.Maybe (Maybe)
 import Data.Symbol (class IsSymbol, SProxy)
-import Halogen.Component (Component, ComponentHTML', mkComponentSlot)
+import Halogen.Component (Component, ComponentSlot, mkComponentSlot)
 import Halogen.Data.Slot (Slot)
 import Halogen.HTML.Core (class IsProp, AttrName(..), ClassName(..), HTML(..), Namespace(..), PropName(..), ElemName(..), text, handler)
 import Halogen.HTML.Core as Core
 import Halogen.HTML.Properties (IProp, attr, attrNS, prop)
-import Prelude (class Ord, Void)
+import Prelude (class Ord, Unit, Void)
 import Prim.Row as Row
 import Unsafe.Coerce (unsafeCoerce)
+
+type ComponentHTML' act ps m = HTML (ComponentSlot HTML ps m act) act
+
+-- | A convenience synonym for the output type of a `render` function, for a
+-- | component that renders HTML.
+type ComponentHTML f ps m = ComponentHTML' (f Unit) ps m
 
 -- | A type useful for a chunk of HTML with no slot-embedding or query-raising.
 -- |

--- a/src/Halogen/HTML.purs
+++ b/src/Halogen/HTML.purs
@@ -15,7 +15,7 @@ import Halogen.HTML.Elements
 
 import Data.Maybe (Maybe)
 import Data.Symbol (class IsSymbol, SProxy)
-import Halogen.Component (Component, ComponentSlot, mkComponentSlot)
+import Halogen.Component (Component, ComponentSlot, componentSlot)
 import Halogen.Data.Slot (Slot)
 import Halogen.HTML.Core (class IsProp, AttrName(..), ClassName(..), HTML(..), Namespace(..), PropName(..), ElemName(..), text, handler)
 import Halogen.HTML.Core as Core
@@ -60,4 +60,4 @@ slot
   -> (o -> Maybe act)
   -> ComponentHTML' act ps m
 slot sym p component input outputQuery =
-  Core.slot (mkComponentSlot sym p component input outputQuery)
+  Core.slot (componentSlot sym p component input outputQuery)

--- a/src/Halogen/HTML/Events.purs
+++ b/src/Halogen/HTML/Events.purs
@@ -92,7 +92,7 @@ input_ :: forall f a. Action f -> a -> Maybe (f Unit)
 input_ f _ = Just $ action f
 
 handler :: forall r i. EventType -> (Event -> Maybe i) -> IProp r i
-handler et = (unsafeCoerce :: (EventType -> (Event -> Maybe i) -> Prop i) -> EventType -> (Event -> Maybe (Input i)) -> IProp r i) Core.handler et <<< map (map Query)
+handler et = (unsafeCoerce :: (EventType -> (Event -> Maybe i) -> Prop i) -> EventType -> (Event -> Maybe (Input i)) -> IProp r i) Core.handler et <<< map (map Action)
 
 onAbort :: forall r i. (Event -> Maybe i) -> IProp (onAbort :: Event | r) i
 onAbort = handler (EventType "abort")

--- a/src/Halogen/Query.purs
+++ b/src/Halogen/Query.purs
@@ -25,8 +25,8 @@ import Halogen.Query.Input (RefLabel(..))
 import Web.HTML.HTMLElement (HTMLElement)
 import Web.HTML.HTMLElement as HTMLElement
 
--- | Type synonym for an "action" - An action only causes effects and has no
--- | result value.
+-- | Type synonym for an "action-style" query - An action only causes effects
+-- | and has no result value.
 -- |
 -- | In a query algebra, an action is any constructor that carries the algebra's
 -- | type variable as a value. For example:
@@ -56,8 +56,8 @@ type Action f = Unit -> f Unit
 action :: forall f. Action f -> f Unit
 action act = act unit
 
--- | Type synonym for an "request" - a request can cause effects as well as
--- | fetching some information from a component.
+-- | Type synonym for an "request-style" query - a request can cause effects as
+-- | well as fetching some information from a component.
 -- |
 -- | In a query algebra, an action is any constructor that carries the algebra's
 -- | type variable as the return value of a function. For example:

--- a/src/Halogen/Query/ChildQuery.purs
+++ b/src/Halogen/Query/ChildQuery.purs
@@ -1,0 +1,31 @@
+module Halogen.Query.ChildQuery where
+
+import Prelude
+
+import Halogen.Data.Slot (SlotStorage)
+import Unsafe.Coerce (unsafeCoerce)
+
+data ChildQueryBox (ps :: # Type) a
+
+data ChildQuery ps g o a f b =
+  ChildQuery
+    (forall slot m. Applicative m => (slot g o -> m b) -> SlotStorage ps slot -> m (f b))
+    (g b)
+    (f b -> a)
+
+instance functorChildQuery :: Functor (ChildQueryBox ps) where
+  map f = unChildQueryBox \(ChildQuery u q k) ->
+    mkChildQueryBox (ChildQuery u q (f <<< k))
+
+mkChildQueryBox
+  :: forall ps g o a f b
+   . ChildQuery ps g o a f b
+  -> ChildQueryBox ps a
+mkChildQueryBox = unsafeCoerce
+
+unChildQueryBox
+  :: forall ps a r
+   . (forall g o f b. ChildQuery ps g o a f b -> r)
+  -> ChildQueryBox ps a
+  -> r
+unChildQueryBox = unsafeCoerce

--- a/src/Halogen/Query/Input.purs
+++ b/src/Halogen/Query/Input.purs
@@ -14,6 +14,6 @@ derive newtype instance ordRefLabel :: Ord RefLabel
 
 data Input act
   = RefUpdate RefLabel (Maybe Element)
-  | Query act
+  | Action act
 
 derive instance functorInput :: Functor Input


### PR DESCRIPTION
Mostly superficial & doc comment updates, made some changes to the naming of things though.

Primed constructors for things that do existential coercion are now `mkX` to match their `unX`, and the `x` naming is reserved for smart constructors that do something internally to make the record.

Rejigged `ChildQuery` stuff a bit so `UnpackQuery` isn't necessary as a separate newtype along with the internal record.