### PR TITLE
`hoist` fusion

### DIFF
--- a/src/Halogen/Component/Profunctor.purs
+++ b/src/Halogen/Component/Profunctor.purs
@@ -17,14 +17,14 @@ instance profunctorProComponent :: Functor f => Profunctor (ProComponent h f m) 
     ProComponent (unComponent (mkComponent <<< dimapSpec f g) c)
 
 dimapSpec
-  :: forall h s f act ps i j o p m
+  :: forall h s f act ps i j o p m n
    . Functor f
   => (j -> i)
   -> (o -> p)
-  -> ComponentSpec h s f act ps i o m
-  -> ComponentSpec h s f act ps j p m
+  -> ComponentSpec h s f act ps i o m n
+  -> ComponentSpec h s f act ps j p m n
 dimapSpec f g spec =
-  { initialState: spec.initialState <<< f
-  , render: spec.render
-  , eval: dimap (lmap f) (HM.mapOutput g) spec.eval
-  }
+  spec
+    { initialState = spec.initialState <<< f
+    , eval = dimap (lmap f) (HM.mapOutput g) spec.eval
+    }


### PR DESCRIPTION
@natefaubion I did all the obvious parts, but it becomes non-obvious where the hole is. Depending on how things are implemented we need `Aff` to be `m'` or vice versa to make things work out, but since `m'` has no constraints we can't actually do anything in `m'`, and if we want it to be `Aff` it appears we need a contravariant mapping too.

I'll let you scratch your head over it for a while 😜 I'm going to press on with fork-auto-clean-up and component disposal.