### PR TITLE
Added `dispose` to `HalogenIO`, active forks are now killed on finalize

### DIFF
--- a/src/Halogen.purs
+++ b/src/Halogen.purs
@@ -15,9 +15,8 @@ module Halogen
 import Prelude
 
 import Control.Coroutine as CR
-
 import Data.Lazy (defer)
-
+import Data.Maybe (Maybe)
 import Halogen.Component (Component, ComponentSpec, ComponentSlot, ComponentSlotSpec, component, mkComponent, hoist, componentSlot, unComponent, unComponentSlot)
 import Halogen.Data.Slot (Slot)
 import Halogen.HTML (ComponentHTML, ComponentHTML')
@@ -25,9 +24,13 @@ import Halogen.HTML.Core (AttrName(..), ClassName(..), Namespace(..), PropName(.
 import Halogen.Query (Action, HalogenF(..), HalogenM, HalogenM'(..), HalogenQ(..), RefLabel(..), Request, SubscriptionId, ForkId, action, fork, kill, get, getHTMLElementRef, getRef, gets, lift, liftAff, liftEffect, modify, modify_, put, query, queryAll, raise, request, subscribe, subscribe', unsubscribe)
 
 -- | A record produced when the root component in a Halogen UI has been run.
--- | `query` allows external sources to query the root component and `subscribe`
--- | allows external consumers to receive messages raised by the root component.
+-- |
+-- | - `query` allows external sources to query the root component
+-- | - `subscribe` allows external consumers to receive messages raised by the
+-- |   root component
+-- | - `dispose` stops running the UI and finalizes the root component
 type HalogenIO f o m =
-  { query :: f ~> m
+  { query :: forall a. f a -> m (Maybe a)
   , subscribe :: CR.Consumer o m Unit -> m Unit
+  , dispose :: m Unit
   }

--- a/src/Halogen/Query.purs
+++ b/src/Halogen/Query.purs
@@ -50,7 +50,7 @@ type Action f = Unit -> f Unit
 -- | ```purescript
 -- | data Query a = Tick a
 -- |
--- | sendTick :: forall o. HalogenIO Query o Aff -> Aff Unit
+-- | sendTick :: forall o. HalogenIO Query o Aff -> Aff (Maybe Unit)
 -- | sendTick app = app.query (action Tick)
 -- | ```
 action :: forall f. Action f -> f Unit
@@ -74,7 +74,7 @@ type Request f a = (a -> a) -> f a
 -- | ```purescript
 -- | data Query a = GetTickCount (Int -> a)
 -- |
--- | getTickCount :: forall o. HalogenIO Query o Aff -> Aff Int
+-- | getTickCount :: forall o. HalogenIO Query o Aff -> Aff (Maybe Int)
 -- | getTickCount app = app.query (request GetTickCount)
 -- | ```
 request :: forall f a. Request f a -> f a

--- a/src/Halogen/Query/HalogenM.purs
+++ b/src/Halogen/Query/HalogenM.purs
@@ -144,6 +144,10 @@ derive newtype instance eqSubscriptionId :: Eq SubscriptionId
 derive newtype instance ordSubscriptionId :: Ord SubscriptionId
 
 -- | Subscribes a component to an `EventSource`.
+-- |
+-- | When a component is disposed of any active subscriptions will automatically
+-- | be stopped and no further subscriptions will be possible during
+-- | finalization.
 subscribe :: forall s act ps o m. ES.EventSource m act -> HalogenM' s act ps o m SubscriptionId
 subscribe es = HalogenM $ liftF $ Subscribe (\_ -> es) identity
 
@@ -152,6 +156,10 @@ subscribe es = HalogenM $ liftF $ Subscribe (\_ -> es) identity
 -- | is passed into an `EventSource` constructor. This allows emitted queries
 -- | to include the `SubscriptionId`, rather than storing it in the state of the
 -- | component.
+-- |
+-- | When a component is disposed of any active subscriptions will automatically
+-- | be stopped and no further subscriptions will be possible during
+-- | finalization.
 subscribe' :: forall s act ps o m. (SubscriptionId -> ES.EventSource m act) -> HalogenM' s act ps o m Unit
 subscribe' esc = HalogenM $ liftF $ Subscribe esc (const unit)
 
@@ -179,6 +187,10 @@ derive newtype instance ordForkId :: Ord ForkId
 -- | Some care needs to be taken when using a `fork` that can modify the
 -- | component state, as it's easy for the forked process to "clobber" the state
 -- | (overwrite some or all of it with an old value) by mistake.
+-- |
+-- | When a component is disposed of any active forks will automatically
+-- | be killed. New forks can be started during finalization but there will be
+-- | no means of killing them.
 fork :: forall s act ps o m. HalogenM' s act ps o m Unit -> HalogenM' s act ps o m ForkId
 fork hmu = HalogenM $ liftF $ Fork hmu identity
 

--- a/src/Halogen/VDom/Driver.purs
+++ b/src/Halogen/VDom/Driver.purs
@@ -104,7 +104,12 @@ renderSpec
   :: DOM.Document
   -> DOM.HTMLElement
   -> AD.RenderSpec HTML RenderState
-renderSpec document container = { render, renderChild: identity, removeChild }
+renderSpec document container =
+    { render
+    , renderChild: identity
+    , removeChild
+    , dispose: removeChild
+    }
   where
 
   render

--- a/test/Test/DocExamples/Action.purs
+++ b/test/Test/DocExamples/Action.purs
@@ -1,10 +1,12 @@
 module Test.DocExamples.Action where
 
 import Prelude
+
+import Data.Maybe (Maybe)
 import Effect.Aff (Aff)
 import Halogen (HalogenIO, action)
 
 data Query a = Tick a
 
-sendTick :: forall o. HalogenIO Query o Aff -> Aff Unit
+sendTick :: forall o. HalogenIO Query o Aff -> Aff (Maybe Unit)
 sendTick io = io.query (action Tick)

--- a/test/Test/DocExamples/Request.purs
+++ b/test/Test/DocExamples/Request.purs
@@ -1,9 +1,11 @@
 module Test.DocExamples.Request where
 
 import Halogen
+
+import Data.Maybe (Maybe)
 import Effect.Aff (Aff)
 
 data Query a = GetTickCount (Int -> a)
 
-getTickCount :: forall o. HalogenIO Query o Aff -> Aff Int
+getTickCount :: forall o. HalogenIO Query o Aff -> Aff (Maybe Int)
 getTickCount app = app.query (request GetTickCount)

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -4,8 +4,14 @@ import Prelude
 
 import Effect (Effect)
 import Effect.Aff (launchAff_)
+import Effect.Class.Console (log)
 import Test.Component.ForkTest as ForkTest
 
 main :: Effect Unit
 main = launchAff_ do
-  ForkTest.test
+
+  log "Test fork/kill"
+  ForkTest.testForkKill
+
+  log "Test fork killed on component finalize"
+  ForkTest.testFinalize

--- a/test/Test/TestDriver.purs
+++ b/test/Test/TestDriver.purs
@@ -22,4 +22,5 @@ runUI = AD.runUI
   { render: \_ _ _ _ -> pure (TestRenderState unit)
   , renderChild: identity
   , removeChild: const (pure unit)
+  , dispose: const (pure unit)
   }


### PR DESCRIPTION
Resolves #544, resolves #546

@natefaubion could you take a look? I actually had to think a while about what this thing should even do :smile:. I made no attempt to block the component `eval`ing internally, but that shouldn't happen if the render driver disposes of the thing properly, making it so there's no chance of raising messages internally anymore (since subscriptions and forks are also killed).