### PR TITLE
Relax getHTMLElementRef to return in HalogenM'

### DIFF
--- a/src/Halogen/Query.purs
+++ b/src/Halogen/Query.purs
@@ -83,5 +83,5 @@ request req = req identity
 -- | Retrieves a `HTMLElement` value that is associated with a `Ref` in the
 -- | rendered output of a component. If there is no currently rendered value (or
 -- | it is not an `HTMLElement`) for the request will return `Nothing`.
-getHTMLElementRef :: forall s f ps o m. RefLabel -> HalogenM s f ps o m (Maybe HTMLElement)
+getHTMLElementRef :: forall s act ps o m. RefLabel -> HalogenM' s act ps o m (Maybe HTMLElement)
 getHTMLElementRef = map (HTMLElement.fromElement =<< _) <<< getRef


### PR DESCRIPTION
`HalgoenM` requires `f :: Type -> Type` rather than `act :: Type`