### PR TITLE
Provide a helpful hint to browse the repo at a particular tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 A declarative, type-safe UI library for PureScript.
 
+> Note: This repository uses tagged releases. For that reason, the master branch does not necessarily represent the current release. To ensure you are viewing the correct documentation and examples, consider browsing the repository at the tag of the release you have specified in your bower or psc-package file.
+
 ## Getting Started
 
 - Read the [guide](https://github.com/slamdata/purescript-halogen/tree/v4.0.0/docs/)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A declarative, type-safe UI library for PureScript.
 
-> Note: This repository uses tagged releases. For that reason, the master branch does not necessarily represent the current release. To ensure you are viewing the correct documentation and examples, consider browsing the repository at the tag of the release you have specified in your bower or psc-package file.
+**Note:** This repository uses tagged releases. For that reason, the master branch does not necessarily represent the current release. To ensure you are viewing the correct documentation and examples, consider browsing the repository at the tag of the release you have specified in your bower or psc-package file.
 
 ## Getting Started
 


### PR DESCRIPTION
It can be confusing to browse the Halogen repo on the master branch and find that the code there doesn't work at all in your project, only to realize later that you _should_ have been browsing at a particular tag instead! Since there is also a `next` branch users might expect `master` to be the 'stable release' branch.

Even though I know better, I've done this myself recently, and I've witnessed confusion for users of `purescript-halogen-formless` for the same reason in that repo. I've added this notice to Formless, and I thought it would be useful for Halogen users as well.