### PR TITLE
Remove purescript-profunctor-lenses dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,7 @@
     "purescript-nullable": "^4.0.0",
     "purescript-ordered-collections": "^1.0.0",
     "purescript-parallel": "^4.0.0",
-    "purescript-profunctor-lenses": "^4.0.0",
+    "purescript-profunctor-lenses": "^5.0.0",
     "purescript-profunctor": "^4.0.0",
     "purescript-transformers": "^4.1.0",
     "purescript-unsafe-coerce": "^4.0.0",

--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,6 @@
     "purescript-nullable": "^4.0.0",
     "purescript-ordered-collections": "^1.0.0",
     "purescript-parallel": "^4.0.0",
-    "purescript-profunctor-lenses": "^5.0.0",
     "purescript-profunctor": "^4.0.0",
     "purescript-transformers": "^4.1.0",
     "purescript-unsafe-coerce": "^4.0.0",


### PR DESCRIPTION
Looks like the `ChildPath` component was the only place this was used, with that gone it seems this isn't a necessary dependency anymore