### PR TITLE
Add associated-type like thing for surface/element

### DIFF
--- a/examples/ace/src/AceComponent.purs
+++ b/examples/ace/src/AceComponent.purs
@@ -53,7 +53,7 @@ initialState _ = { editor: Nothing }
 render :: forall m. State -> H.ComponentHTML Action () m
 render = const $ HH.div [ HP.ref (H.RefLabel "ace") ] []
 
-handleAction :: forall m. MonadAff m => Action -> H.HalogenM State Action () Output m Unit
+handleAction :: forall m. MonadAff m => Action -> H.HalogenM HH.HTML State Action () Output m Unit
 handleAction = case _ of
   Initialize -> do
     H.getHTMLElementRef (H.RefLabel "ace") >>= traverse_ \element -> do
@@ -72,7 +72,7 @@ handleAction = case _ of
       text <- H.liftEffect (Editor.getValue editor)
       H.raise $ TextChanged text
 
-handleQuery :: forall m a. MonadAff m => Query a -> H.HalogenM State Action () Output m (Maybe a)
+handleQuery :: forall m a. MonadAff m => Query a -> H.HalogenM HH.HTML State Action () Output m (Maybe a)
 handleQuery = case _ of
   ChangeText text next -> do
     maybeEditor <- H.gets _.editor

--- a/examples/ace/src/Container.purs
+++ b/examples/ace/src/Container.purs
@@ -55,14 +55,14 @@ render { text: text } =
         [ HH.text ("Current text: " <> text) ]
     ]
 
-handleAction :: forall o m. MonadAff m => Action -> H.HalogenM State Action ChildSlots o m Unit
+handleAction :: forall o m. MonadAff m => Action -> H.HalogenM HH.HTML State Action ChildSlots o m Unit
 handleAction = case _ of
   ClearText ->
     void $ H.query _ace unit $ H.tell (AceComponent.ChangeText "")
   HandleAceUpdate msg ->
     handleAceOuput msg
 
-handleAceOuput :: forall o m. MonadAff m => AceComponent.Output -> H.HalogenM State Action ChildSlots o m Unit
+handleAceOuput :: forall o m. MonadAff m => AceComponent.Output -> H.HalogenM HH.HTML State Action ChildSlots o m Unit
 handleAceOuput = case _ of
   AceComponent.TextChanged text ->
     H.modify_ (_ { text = text })

--- a/examples/basic/src/Button.purs
+++ b/examples/basic/src/Button.purs
@@ -34,7 +34,7 @@ render state =
       ]
       [ HH.text label ]
 
-handleAction ∷ forall o m. Action → H.HalogenM State Action () o m Unit
+handleAction ∷ forall o m. Action → H.HalogenM HH.HTML State Action () o m Unit
 handleAction = case _ of
   Toggle ->
     H.modify_ \st -> st { enabled = not st.enabled }

--- a/examples/components-inputs/src/Container.purs
+++ b/examples/components-inputs/src/Container.purs
@@ -50,7 +50,7 @@ render state =
         [ HH.text "-1"]
     ]
 
-handleAction :: forall o m. Action -> H.HalogenM State Action ChildSlots o m Unit
+handleAction :: forall o m. Action -> H.HalogenM HH.HTML State Action ChildSlots o m Unit
 handleAction = case _ of
   Increment ->
     H.modify_ (_ + 1)

--- a/examples/components-inputs/src/Display.purs
+++ b/examples/components-inputs/src/Display.purs
@@ -32,7 +32,7 @@ render state =
     , HH.strong_ [ HH.text (show state) ]
     ]
 
-handleAction :: forall o m. Action -> H.HalogenM State Action () o m Unit
+handleAction :: forall o m. Action -> H.HalogenM HH.HTML State Action () o m Unit
 handleAction = case _ of
   HandleInput n -> do
     oldN <- H.get

--- a/examples/components-multitype/src/ComponentA.purs
+++ b/examples/components-multitype/src/ComponentA.purs
@@ -39,12 +39,12 @@ render state =
         [ HH.text (if state then "On" else "Off") ]
     ]
 
-handleAction :: forall o m. Action -> H.HalogenM State Action () o m Unit
+handleAction :: forall o m. Action -> H.HalogenM HH.HTML State Action () o m Unit
 handleAction = case _ of
   Toggle ->
     H.modify_ not
 
-handleQuery :: forall o m a. Query a -> H.HalogenM State Action () o m (Maybe a)
+handleQuery :: forall o m a. Query a -> H.HalogenM HH.HTML State Action () o m (Maybe a)
 handleQuery = case _ of
   IsOn k -> do
     enabled <- H.get

--- a/examples/components-multitype/src/ComponentB.purs
+++ b/examples/components-multitype/src/ComponentB.purs
@@ -42,12 +42,12 @@ render state =
         [ HH.text ("Increment") ]
     ]
 
-handleAction :: forall o m. Action -> H.HalogenM State Action () o m Unit
+handleAction :: forall o m. Action -> H.HalogenM HH.HTML State Action () o m Unit
 handleAction = case _ of
   Increment ->
     H.modify_ (_ + 1)
 
-handleQuery :: forall o m a. Query a -> H.HalogenM State Action () o m (Maybe a)
+handleQuery :: forall o m a. Query a -> H.HalogenM HH.HTML State Action () o m (Maybe a)
 handleQuery = case _ of
   GetCount k ->
     Just <<< k <$> H.get

--- a/examples/components-multitype/src/ComponentC.purs
+++ b/examples/components-multitype/src/ComponentC.purs
@@ -41,12 +41,12 @@ render state =
         ]
     ]
 
-handleAction :: forall o m. Action -> H.HalogenM State Action () o m Unit
+handleAction :: forall o m. Action -> H.HalogenM HH.HTML State Action () o m Unit
 handleAction = case _ of
   HandleInput value ->
     H.put value
 
-handleQuery :: forall o m a. Query a -> H.HalogenM State Action () o m (Maybe a)
+handleQuery :: forall o m a. Query a -> H.HalogenM HH.HTML State Action () o m (Maybe a)
 handleQuery = case _ of
   GetValue k ->
     Just <<< k <$> H.get

--- a/examples/components-multitype/src/Container.purs
+++ b/examples/components-multitype/src/Container.purs
@@ -70,7 +70,7 @@ render state = HH.div_
       [ HH.text "Check states now" ]
   ]
 
-handleAction :: forall o m. Action -> H.HalogenM State Action ChildSlots o m Unit
+handleAction :: forall o m. Action -> H.HalogenM HH.HTML State Action ChildSlots o m Unit
 handleAction = case _ of
   ReadStates -> do
     a <- H.query _a unit (H.request CA.IsOn)

--- a/examples/components/src/Button.purs
+++ b/examples/components/src/Button.purs
@@ -43,13 +43,13 @@ render state =
       ]
       [ HH.text label ]
 
-handleAction :: forall m. Action -> H.HalogenM State Action () Message m Unit
+handleAction :: forall m. Action -> H.HalogenM HH.HTML State Action () Message m Unit
 handleAction = case _ of
   Toggle -> do
     newState <- H.modify \st -> st { enabled = not st.enabled }
     H.raise (Toggled newState.enabled)
 
-handleQuery :: forall m a. Query a -> H.HalogenM State Action () Message m (Maybe a)
+handleQuery :: forall m a. Query a -> H.HalogenM HH.HTML State Action () Message m (Maybe a)
 handleQuery = case _ of
   IsOn k -> do
     enabled <- H.gets _.enabled

--- a/examples/components/src/Container.purs
+++ b/examples/components/src/Container.purs
@@ -56,7 +56,7 @@ render state =
         ]
     ]
 
-handleAction ::forall o m. Action -> H.HalogenM State Action ChildSlots o m Unit
+handleAction ::forall o m. Action -> H.HalogenM HH.HTML State Action ChildSlots o m Unit
 handleAction = case _ of
   HandleButton (Button.Toggled _) -> do
     H.modify_ (\st -> st { toggleCount = st.toggleCount + 1 })

--- a/examples/driver-io/src/Button.purs
+++ b/examples/driver-io/src/Button.purs
@@ -45,13 +45,13 @@ render state =
       ]
       [ HH.text label ]
 
-handleAction :: forall m. Action -> H.HalogenM State Action () Message m Unit
+handleAction :: forall m. Action -> H.HalogenM HH.HTML State Action () Message m Unit
 handleAction = case _ of
   Toggle -> do
     newState <- H.modify \st -> st { enabled = not st.enabled }
     H.raise (Toggled newState.enabled)
 
-handleQuery :: forall m a. Query a -> H.HalogenM State Action () Message m (Maybe a)
+handleQuery :: forall m a. Query a -> H.HalogenM HH.HTML State Action () Message m (Maybe a)
 handleQuery = case _ of
   IsOn k -> do
     enabled <- H.gets _.enabled

--- a/examples/driver-routing/src/RouteLog.purs
+++ b/examples/driver-routing/src/RouteLog.purs
@@ -38,7 +38,7 @@ render state =
     , HH.ol_ $ map (\msg -> HH.li_ [ HH.text msg ]) state.history
     ]
 
-handleQuery :: forall act o m a. Query a -> H.HalogenM State act () o m (Maybe a)
+handleQuery :: forall act o m a. Query a -> H.HalogenM HH.HTML State act () o m (Maybe a)
 handleQuery = case _ of
   ChangeRoute msg a -> do
     H.modify_ \st -> { history: st.history `A.snoc` msg }

--- a/examples/driver-websockets/src/Log.purs
+++ b/examples/driver-websockets/src/Log.purs
@@ -56,7 +56,7 @@ render state =
         [ HH.text "Send Message" ]
     ]
 
-handleAction :: forall m. MonadEffect m => Action -> H.HalogenM State Action () Message m Unit
+handleAction :: forall m. MonadEffect m => Action -> H.HalogenM HH.HTML State Action () Message m Unit
 handleAction = case _ of
   HandleInput text -> do
     H.modify_ (_ { inputText = text })
@@ -70,7 +70,7 @@ handleAction = case _ of
       , inputText = ""
       }
 
-handleQuery :: forall m a. Query a -> H.HalogenM State Action () Message m (Maybe a)
+handleQuery :: forall m a. Query a -> H.HalogenM HH.HTML State Action () Message m (Maybe a)
 handleQuery = case _ of
   ReceiveMessage msg a -> do
     let incomingMessage = "Received: " <> msg

--- a/examples/effects-aff-ajax/src/Component.purs
+++ b/examples/effects-aff-ajax/src/Component.purs
@@ -65,7 +65,7 @@ render st =
             ]
     ]
 
-handleAction :: forall o m. MonadAff m => Action -> H.HalogenM State Action () o m Unit
+handleAction :: forall o m. MonadAff m => Action -> H.HalogenM HH.HTML State Action () o m Unit
 handleAction = case _ of
   SetUsername username -> do
     H.modify_ (_ { username = username, result = Nothing :: Maybe String })

--- a/examples/effects-eff-random/src/Component.purs
+++ b/examples/effects-eff-random/src/Component.purs
@@ -37,7 +37,7 @@ render state =
           [ HH.text "Generate new number" ]
       ]
 
-handleAction :: forall o m. MonadEffect m => Action -> H.HalogenM State Action () o m Unit
+handleAction :: forall o m. MonadEffect m => Action -> H.HalogenM HH.HTML State Action () o m Unit
 handleAction = case _ of
   Regenerate -> do
     newNumber <- H.liftEffect random

--- a/examples/higher-order-components/src/Button.purs
+++ b/examples/higher-order-components/src/Button.purs
@@ -43,13 +43,13 @@ render state =
       ]
       [ HH.text label ]
 
-handleAction :: forall m. Action -> H.HalogenM State Action () Message m Unit
+handleAction :: forall m. Action -> H.HalogenM HH.HTML State Action () Message m Unit
 handleAction = case _ of
   Toggle -> do
     newState <- H.modify \st -> st { enabled = not st.enabled }
     H.raise (Toggled newState.enabled)
 
-handleQuery :: forall m a. Query a -> H.HalogenM State Action () Message m (Maybe a)
+handleQuery :: forall m a. Query a -> H.HalogenM HH.HTML State Action () Message m (Maybe a)
 handleQuery = case _ of
   IsOn k -> do
     enabled <- H.gets _.enabled

--- a/examples/higher-order-components/src/Harness.purs
+++ b/examples/higher-order-components/src/Harness.purs
@@ -61,7 +61,7 @@ printButtonState = case _ of
 panelComponent :: forall m. H.Component HH.HTML (Panel.Query Button.Query) Unit (Panel.Message Button.Message) m
 panelComponent = Panel.component Button.component
 
-handleAction :: forall o m. Action -> H.HalogenM State Action ChildSlots o m Unit
+handleAction :: forall o m. Action -> H.HalogenM HH.HTML State Action ChildSlots o m Unit
 handleAction = case _ of
   CheckButtonState -> do
     buttonCheckState <- H.query _panel unit $ H.request (Panel.QueryInner <<< Button.IsOn)
@@ -69,7 +69,7 @@ handleAction = case _ of
   HandlePanelMessage msg ->
     handlePanelMessage msg
 
-handlePanelMessage :: forall o m. Panel.Message Button.Message -> H.HalogenM State Action ChildSlots o m Unit
+handlePanelMessage :: forall o m. Panel.Message Button.Message -> H.HalogenM HH.HTML State Action ChildSlots o m Unit
 handlePanelMessage = case _ of
   Panel.Opened ->
     pure unit
@@ -78,7 +78,7 @@ handlePanelMessage = case _ of
   Panel.Bubble msg ->
     handleButtonMessage msg
 
-handleButtonMessage  :: forall o m. Button.Message -> H.HalogenM State Action ChildSlots o m Unit
+handleButtonMessage  :: forall o m. Button.Message -> H.HalogenM HH.HTML State Action ChildSlots o m Unit
 handleButtonMessage = case _ of
   Button.Toggled b ->
     H.modify_ (_ { buttonMessageState = Just b })

--- a/examples/higher-order-components/src/Panel.purs
+++ b/examples/higher-order-components/src/Panel.purs
@@ -90,7 +90,7 @@ render innerComponent state
 handleAction
   :: forall f i o m
    . Action o
-  -> H.HalogenM (State i) (Action o) (ChildSlots f o) (Message o) m Unit
+  -> H.HalogenM HH.HTML (State i) (Action o) (ChildSlots f o) (Message o) m Unit
 handleAction = case _ of
   Toggle -> do
     st' <- H.modify \st -> st { open = not st.open }
@@ -101,7 +101,7 @@ handleAction = case _ of
 handleQuery
   :: forall f i o m a
    . Query f a
-  -> H.HalogenM (State i) (Action o) (ChildSlots f o) (Message o) m (Maybe a)
+  -> H.HalogenM HH.HTML (State i) (Action o) (ChildSlots f o) (Message o) m (Maybe a)
 handleQuery = case _ of
   SetOpen b a -> do
     H.modify_ (_ { open = b })

--- a/examples/interpret/src/Main.purs
+++ b/examples/interpret/src/Main.purs
@@ -56,7 +56,7 @@ searchUser q = do
       lift (AX.get AXRF.string ("https://api.github.com/users/" <> q <> "?access_token=" <> token))
   pure (either (const "") identity body)
 
-handleAction :: forall o. Action -> H.HalogenM State Action () o (ReaderT Config Aff) Unit
+handleAction :: forall o. Action -> H.HalogenM HH.HTML State Action () o (ReaderT Config Aff) Unit
 handleAction = case _ of
   FetchData -> do
     userData <- lift (searchUser "kRITZCREEK")

--- a/examples/keyboard-input/src/Main.purs
+++ b/examples/keyboard-input/src/Main.purs
@@ -45,7 +45,7 @@ ui =
       , HH.p_ [ HH.text state.chars ]
       ]
 
-handleAction :: forall o. Action -> H.HalogenM State Action () o Aff Unit
+handleAction :: forall o. Action -> H.HalogenM HH.HTML State Action () o Aff Unit
 handleAction = case _ of
   Init -> do
     document <- H.liftEffect $ Web.document =<< Web.window

--- a/examples/lifecycle/src/Child.purs
+++ b/examples/lifecycle/src/Child.purs
@@ -51,7 +51,7 @@ child initialState =
         ]
       ]
 
-  handleAction :: Action -> H.HalogenM Int Action ChildSlots Message Aff Unit
+  handleAction :: Action -> H.HalogenM HH.HTML Int Action ChildSlots Message Aff Unit
   handleAction Initialize = do
     id <- H.get
     H.liftEffect $ log ("Initialize Child " <> show id)
@@ -88,7 +88,7 @@ cell initialState =
   render id =
     HH.li_ [ HH.text ("Cell " <> show id) ]
 
-  handleAction :: Action -> H.HalogenM Int Action () Message Aff Unit
+  handleAction :: Action -> H.HalogenM HH.HTML Int Action () Message Aff Unit
   handleAction Initialize = do
     id <- H.get
     H.liftEffect $ log ("Initialize Cell " <> show id)

--- a/examples/lifecycle/src/Main.purs
+++ b/examples/lifecycle/src/Main.purs
@@ -74,7 +74,7 @@ ui =
               ]
       ]
 
-  handleAction :: forall o. Action -> H.HalogenM State Action ChildSlots o Aff Unit
+  handleAction :: forall o. Action -> H.HalogenM HH.HTML State Action ChildSlots o Aff Unit
   handleAction Initialize =
     H.liftEffect $ log "Initialize Root"
   handleAction Finalize =

--- a/src/Halogen/Aff/Driver.purs
+++ b/src/Halogen/Aff/Driver.purs
@@ -97,7 +97,7 @@ import Halogen.Query.Input as Input
 type RenderSpec h r =
   { render
       :: forall s act ps o
-       . (Input act -> Effect Unit)
+       . (Input h act -> Effect Unit)
       -> (ComponentSlotBox h ps Aff act -> Effect (RenderStateX r))
       -> h (ComponentSlot h ps Aff act) act
       -> Maybe (r s act ps o)
@@ -194,7 +194,7 @@ runUI renderSpec component i = do
       pendingHandlers = identity ds.pendingHandlers
       pendingQueries = identity ds.pendingQueries
       selfRef = identity ds.selfRef
-      handler :: Input act -> Aff Unit
+      handler :: Input h act -> Aff Unit
       handler = Eval.queueOrRun pendingHandlers <<< void <<< Eval.evalF render selfRef
       childHandler :: act -> Aff Unit
       childHandler = Eval.queueOrRun pendingQueries <<< handler <<< Input.Action

--- a/src/Halogen/Aff/Driver/Eval.purs
+++ b/src/Halogen/Aff/Driver/Eval.purs
@@ -46,7 +46,7 @@ evalF
   :: forall h r s f act ps i o
    . Renderer h r
   -> Ref (DriverState h r s f act ps i o)
-  -> Input act
+  -> Input h act
   -> Aff Unit
 evalF render ref = case _ of
   Input.RefUpdate (Input.RefLabel p) el -> do
@@ -70,14 +70,14 @@ evalM
   :: forall h r s f act ps i o
    . Renderer h r
   -> Ref (DriverState h r s f act ps i o)
-  -> HalogenM s act ps o Aff
+  -> HalogenM h s act ps o Aff
   ~> Aff
 evalM render initRef (HalogenM hm) = foldFree (go initRef) hm
   where
   go
     :: forall s' f' act' ps' i' o'
      . Ref (DriverState h r s' f' act' ps' i' o')
-    -> HalogenF s' act' ps' o' Aff
+    -> HalogenF h s' act' ps' o' Aff
     ~> Aff
   go ref = case _ of
     State f -> do

--- a/src/Halogen/Aff/Driver/State.purs
+++ b/src/Halogen/Aff/Driver/State.purs
@@ -29,8 +29,8 @@ import Halogen.Data.Slot (SlotStorage)
 import Halogen.Data.Slot as SlotStorage
 import Halogen.Query.EventSource (Finalizer)
 import Halogen.Query.HalogenM (ForkId, SubscriptionId)
+import Halogen.Surface (SurfaceElement)
 import Unsafe.Coerce (unsafeCoerce)
-import Web.DOM (Element)
 
 type LifecycleHandlers =
   { initializers :: List (Aff Unit)
@@ -42,7 +42,7 @@ newtype DriverState h r s f act ps i o = DriverState (DriverStateRec h r s f act
 type DriverStateRec h r s f act ps i o =
   { component :: ComponentSpec h s f act ps i o Aff
   , state :: s
-  , refs :: M.Map String Element
+  , refs :: M.Map String (SurfaceElement h)
   , children :: SlotStorage ps (DriverStateRef h r)
   , childrenIn :: Ref (SlotStorage ps (DriverStateRef h r))
   , childrenOut :: Ref (SlotStorage ps (DriverStateRef h r))

--- a/src/Halogen/Component.purs
+++ b/src/Halogen/Component.purs
@@ -83,7 +83,7 @@ data Component
 type ComponentSpec surface state query action slots input output m =
   { initialState :: input -> state
   , render :: state -> surface (ComponentSlot surface slots m action) action
-  , eval :: HalogenQ query action input ~> HalogenM state action slots output m
+  , eval :: HalogenQ query action input ~> HalogenM surface state action slots output m
   }
 
 -- | Constructs a [`Component`](#t:Component) from a [`ComponentSpec`](#t:ComponentSpec).
@@ -131,9 +131,9 @@ hoist nat = unComponent \c ->
 -- | more convenient for common cases.
 -- |
 -- | See below for more details about `mkEval` and `defaultEval`.
-type EvalSpec state query action slots input output m =
-  { handleAction :: action -> HalogenM state action slots output m Unit
-  , handleQuery :: forall a. query a -> HalogenM state action slots output m (Maybe a)
+type EvalSpec surface state query action slots input output m =
+  { handleAction :: action -> HalogenM surface state action slots output m Unit
+  , handleQuery :: forall a. query a -> HalogenM surface state action slots output m (Maybe a)
   , receive :: input -> Maybe action
   , initialize :: Maybe action
   , finalize :: Maybe action
@@ -154,7 +154,7 @@ type EvalSpec state query action slots input output m =
 -- |   , eval: H.mkEval (H.defaultEval { handleAction = ?handleAction })
 -- |   }
 -- | ```
-defaultEval :: forall state query action slots input output m. EvalSpec state query action slots input output m
+defaultEval :: forall surface state query action slots input output m. EvalSpec surface state query action slots input output m
 defaultEval =
   { handleAction: const (pure unit)
   , handleQuery: const (pure Nothing)
@@ -165,10 +165,10 @@ defaultEval =
 
 -- | Accepts an `EvalSpec` to produce an `eval` function for a component.
 mkEval
-  :: forall state query action slots input output m
-   . EvalSpec state query action slots input output m
+  :: forall surface state query action slots input output m
+   . EvalSpec surface state query action slots input output m
   -> HalogenQ query action input
-  ~> HalogenM state action slots output m
+  ~> HalogenM surface state action slots output m
 mkEval args = case _ of
   Initialize a ->
     traverse_ args.handleAction args.initialize $> a

--- a/src/Halogen/HTML/Core.purs
+++ b/src/Halogen/HTML/Core.purs
@@ -40,6 +40,7 @@ import Data.MediaType (MediaType)
 import Data.Newtype (class Newtype, un, unwrap)
 import Data.Tuple (Tuple)
 import Halogen.Query.Input (Input)
+import Halogen.Surface (class Surface)
 import Halogen.VDom (ElemName(..), Namespace(..)) as Exports
 import Halogen.VDom.DOM.Prop (ElemRef(..), Prop(..), PropValue, propFromBoolean, propFromInt, propFromNumber, propFromString)
 import Halogen.VDom.DOM.Prop (Prop(..), PropValue) as Exports
@@ -48,7 +49,7 @@ import Unsafe.Coerce (unsafeCoerce)
 import Web.DOM.Element (Element)
 import Web.Event.Event (Event, EventType)
 
-newtype HTML w i = HTML (VDom.VDom (Array (Prop (Input i))) w)
+newtype HTML w i = HTML (VDom.VDom (Array (Prop (Input HTML i))) w)
 
 derive instance newtypeHTML :: Newtype (HTML w i) _
 
@@ -57,6 +58,8 @@ instance bifunctorHTML :: Bifunctor HTML where
 
 instance functorHTML :: Functor (HTML p) where
   map = rmap
+
+instance surfaceHTML :: Surface HTML Element
 
 renderWidget ∷ ∀ w x i j. (i → j) → (w → HTML x j) → HTML w i → HTML x j
 renderWidget f g (HTML vdom) =

--- a/src/Halogen/HTML/Elements.purs
+++ b/src/Halogen/HTML/Elements.purs
@@ -191,7 +191,7 @@ withKeys ctor props children =
     HTML (VDom.Elem x y z _) -> HTML (VDom.Keyed x y z (coe children))
     h -> h
   where
-  coe :: Array (Tuple String (HTML w i)) -> Array (Tuple String (VDom.VDom (Array (Prop (Input i))) w))
+  coe :: Array (Tuple String (HTML w i)) -> Array (Tuple String (VDom.VDom (Array (Prop (Input HTML i))) w))
   coe = unsafeCoerce
 
 withKeys_ :: forall w i. (Array (HTML w i) -> HTML w i) -> Array (Tuple String (HTML w i)) -> HTML w i
@@ -200,7 +200,7 @@ withKeys_ ctor children =
     HTML (VDom.Elem x y z _) -> HTML (VDom.Keyed x y z (coe children))
     h -> h
   where
-  coe :: Array (Tuple String (HTML w i)) -> Array (Tuple String (VDom.VDom (Array (Prop (Input i))) w))
+  coe :: Array (Tuple String (HTML w i)) -> Array (Tuple String (VDom.VDom (Array (Prop (Input HTML i))) w))
   coe = unsafeCoerce
 
 a :: forall w i. Node I.HTMLa w i

--- a/src/Halogen/HTML/Events.purs
+++ b/src/Halogen/HTML/Events.purs
@@ -60,7 +60,7 @@ import Data.Either (either)
 import Data.Maybe (Maybe(..))
 import Foreign (F, Foreign, readBoolean, readInt, readString, unsafeToForeign)
 import Foreign.Index (readProp)
-import Halogen.HTML.Core (Prop)
+import Halogen.HTML.Core (HTML, Prop)
 import Halogen.HTML.Core as Core
 import Halogen.HTML.Properties (IProp)
 import Halogen.Query.Input (Input(..))
@@ -83,7 +83,7 @@ import Web.UIEvent.WheelEvent (WheelEvent)
 import Web.UIEvent.WheelEvent.EventTypes as WET
 
 handler :: forall r i. EventType -> (Event -> Maybe i) -> IProp r i
-handler et = (unsafeCoerce :: (EventType -> (Event -> Maybe i) -> Prop i) -> EventType -> (Event -> Maybe (Input i)) -> IProp r i) Core.handler et <<< map (map Action)
+handler et = (unsafeCoerce :: (EventType -> (Event -> Maybe i) -> Prop i) -> EventType -> (Event -> Maybe (Input HTML i)) -> IProp r i) Core.handler et <<< map (map Action)
 
 onAbort :: forall r i. (Event -> Maybe i) -> IProp (onAbort :: Event | r) i
 onAbort = handler (EventType "abort")

--- a/src/Halogen/Query.purs
+++ b/src/Halogen/Query.purs
@@ -19,6 +19,7 @@ import Control.Monad.Trans.Class (lift) as Exports
 import Data.Maybe (Maybe)
 import Effect.Aff.Class (liftAff) as Exports
 import Effect.Class (liftEffect) as Exports
+import Halogen.HTML as HH
 import Halogen.Query.HalogenM (HalogenM(..), HalogenF(..), SubscriptionId, ForkId, fork, kill, getRef, query, queryAll, subscribe, subscribe', unsubscribe, raise)
 import Halogen.Query.HalogenQ (HalogenQ(..))
 import Halogen.Query.Input (RefLabel(..))
@@ -85,7 +86,7 @@ request req = req identity
 -- | rendered output of a component. If there is no currently rendered value (or
 -- | it is not an `HTMLElement`) for the request will return `Nothing`.
 getHTMLElementRef
-  :: forall surface action slots output m
+  :: forall state action slots output m
    . RefLabel
-  -> HalogenM surface action slots output m (Maybe HTMLElement)
+  -> HalogenM HH.HTML state action slots output m (Maybe HTMLElement)
 getHTMLElementRef = map (HTMLElement.fromElement =<< _) <<< getRef

--- a/src/Halogen/Query/HalogenM.purs
+++ b/src/Halogen/Query/HalogenM.purs
@@ -27,23 +27,24 @@ import Halogen.Data.Slot as Slot
 import Halogen.Query.ChildQuery as CQ
 import Halogen.Query.EventSource as ES
 import Halogen.Query.Input (RefLabel)
+import Halogen.Surface (class Surface, SurfaceElement)
+import Halogen.Surface as Surface
 import Prim.Row as Row
-import Web.DOM (Element)
 
 -- | The Halogen component eval algebra.
-data HalogenF state action slots output m a
+data HalogenF surface state action slots output m a
   = State (state -> Tuple a state)
   | Subscribe (SubscriptionId -> ES.EventSource m action) (SubscriptionId -> a)
   | Unsubscribe SubscriptionId a
   | Lift (m a)
   | ChildQuery (CQ.ChildQueryBox slots a)
   | Raise output a
-  | Par (HalogenAp state action slots output m a)
-  | Fork (HalogenM state action slots output m Unit) (ForkId -> a)
+  | Par (HalogenAp surface state action slots output m a)
+  | Fork (HalogenM surface state action slots output m Unit) (ForkId -> a)
   | Kill ForkId a
-  | GetRef RefLabel (Maybe Element -> a)
+  | GetRef RefLabel (Maybe (SurfaceElement surface) -> a)
 
-instance functorHalogenF :: Functor m => Functor (HalogenF state action slots output m) where
+instance functorHalogenF :: Functor m => Functor (HalogenF surface state action slots output m) where
   map f = case _ of
     State k -> State (lmap f <<< k)
     Subscribe fes k -> Subscribe fes (f <<< k)
@@ -57,78 +58,78 @@ instance functorHalogenF :: Functor m => Functor (HalogenF state action slots ou
     GetRef p k -> GetRef p (f <<< k)
 
 -- | The Halogen component eval effect monad.
-newtype HalogenM state action slots output m a = HalogenM (Free (HalogenF state action slots output m) a)
+newtype HalogenM surface state action slots output m a = HalogenM (Free (HalogenF surface state action slots output m) a)
 
-derive newtype instance functorHalogenM :: Functor (HalogenM state action slots output m)
-derive newtype instance applyHalogenM :: Apply (HalogenM state action slots output m)
-derive newtype instance applicativeHalogenM :: Applicative (HalogenM state action slots output m)
-derive newtype instance bindHalogenM :: Bind (HalogenM state action slots output m)
-derive newtype instance monadHalogenM :: Monad (HalogenM state action slots output m)
+derive newtype instance functorHalogenM :: Functor (HalogenM surface state action slots output m)
+derive newtype instance applyHalogenM :: Apply (HalogenM surface state action slots output m)
+derive newtype instance applicativeHalogenM :: Applicative (HalogenM surface state action slots output m)
+derive newtype instance bindHalogenM :: Bind (HalogenM surface state action slots output m)
+derive newtype instance monadHalogenM :: Monad (HalogenM surface state action slots output m)
 
-instance monadEffectHalogenM :: MonadEffect m => MonadEffect (HalogenM state action slots output m) where
+instance monadEffectHalogenM :: MonadEffect m => MonadEffect (HalogenM surface state action slots output m) where
   liftEffect = HalogenM <<< liftF <<< Lift <<< liftEffect
 
-instance monadAffHalogenM :: MonadAff m => MonadAff (HalogenM state action slots output m) where
+instance monadAffHalogenM :: MonadAff m => MonadAff (HalogenM surface state action slots output m) where
   liftAff = HalogenM <<< liftF <<< Lift <<< liftAff
 
-instance parallelHalogenM :: Parallel (HalogenAp state action slots output m) (HalogenM state action slots output m) where
+instance parallelHalogenM :: Parallel (HalogenAp surface state action slots output m) (HalogenM surface state action slots output m) where
   parallel = HalogenAp <<< liftFreeAp
   sequential = HalogenM <<< liftF <<< Par
 
-instance monadTransHalogenM :: MonadTrans (HalogenM state action slots o) where
+instance monadTransHalogenM :: MonadTrans (HalogenM surface state action slots o) where
   lift = HalogenM <<< liftF <<< Lift
 
-instance monadRecHalogenM :: MonadRec (HalogenM state action slots output m) where
+instance monadRecHalogenM :: MonadRec (HalogenM surface state action slots output m) where
   tailRecM k a = k a >>= case _ of
     Loop x -> tailRecM k x
     Done y -> pure y
 
-instance monadStateHalogenM :: MonadState state (HalogenM state action slots output m) where
+instance monadStateHalogenM :: MonadState state (HalogenM surface state action slots output m) where
   state = HalogenM <<< liftF <<< State
 
-instance monadAskHalogenM :: MonadAsk r m => MonadAsk r (HalogenM state action slots output m) where
+instance monadAskHalogenM :: MonadAsk r m => MonadAsk r (HalogenM surface state action slots output m) where
   ask = HalogenM $ liftF $ Lift ask
 
-instance monadTellHalogenM :: MonadTell w m => MonadTell w (HalogenM state action slots output m) where
+instance monadTellHalogenM :: MonadTell w m => MonadTell w (HalogenM surface state action slots output m) where
   tell = HalogenM <<< liftF <<< Lift <<< tell
 
-instance monadThrowHalogenM :: MonadThrow e m => MonadThrow e (HalogenM state action slots output m) where
+instance monadThrowHalogenM :: MonadThrow e m => MonadThrow e (HalogenM surface state action slots output m) where
   throwError = HalogenM <<< liftF <<< Lift <<< throwError
 
 -- | An applicative-only version of `HalogenM` to allow for parallel evaluation.
-newtype HalogenAp state action slots output m a = HalogenAp (FreeAp (HalogenM state action slots output m) a)
+newtype HalogenAp surface state action slots output m a = HalogenAp (FreeAp (HalogenM surface state action slots output m) a)
 
-derive instance newtypeHalogenAp :: Newtype (HalogenAp state query slots output m a) _
-derive newtype instance functorHalogenAp :: Functor (HalogenAp state query slots output m)
-derive newtype instance applyHalogenAp :: Apply (HalogenAp state query slots output m)
-derive newtype instance applicativeHalogenAp :: Applicative (HalogenAp state query slots output m)
+derive instance newtypeHalogenAp :: Newtype (HalogenAp surface state query slots output m a) _
+derive newtype instance functorHalogenAp :: Functor (HalogenAp surface state query slots output m)
+derive newtype instance applyHalogenAp :: Apply (HalogenAp surface state query slots output m)
+derive newtype instance applicativeHalogenAp :: Applicative (HalogenAp surface state query slots output m)
 
 -- | Raises an output message for the component.
-raise :: forall state action slots output m. output -> HalogenM state action slots output m Unit
+raise :: forall surface state action slots output m. output -> HalogenM surface state action slots output m Unit
 raise o = HalogenM $ liftF $ Raise o unit
 
 -- | Sends a query to a child of a component at the specified slot.
 query
-  :: forall state action output m label slots query output' slot a _1
+  :: forall surface state action output m label slots query output' slot a _1
    . Row.Cons label (Slot query output' slot) _1 slots
   => IsSymbol label
   => Ord slot
   => SProxy label
   -> slot
   -> query a
-  -> HalogenM state action slots output m (Maybe a)
+  -> HalogenM surface state action slots output m (Maybe a)
 query label p q = HalogenM $ liftF $ ChildQuery $ CQ.mkChildQueryBox $
   CQ.ChildQuery (\k → maybe (pure Nothing) k <<< Slot.lookup label p) q identity
 
 -- | Sends a query to all children of a component at a given slot label.
 queryAll
-  :: forall state action output m label slots query output' slot a _1
+  :: forall surface state action output m label slots query output' slot a _1
    . Row.Cons label (Slot query output' slot) _1 slots
   => IsSymbol label
   => Ord slot
   => SProxy label
   -> query a
-  -> HalogenM state action slots output m (Map slot a)
+  -> HalogenM surface state action slots output m (Map slot a)
 queryAll label q =
   HalogenM $ liftF $ ChildQuery $ CQ.mkChildQueryBox $
     CQ.ChildQuery (\k -> map catMapMaybes <<< traverse k <<< Slot.slots label) q identity
@@ -148,7 +149,7 @@ derive newtype instance ordSubscriptionId :: Ord SubscriptionId
 -- | When a component is disposed of any active subscriptions will automatically
 -- | be stopped and no further subscriptions will be possible during
 -- | finalization.
-subscribe :: forall state action slots output m. ES.EventSource m action -> HalogenM state action slots output m SubscriptionId
+subscribe :: forall surface state action slots output m. ES.EventSource m action -> HalogenM surface state action slots output m SubscriptionId
 subscribe es = HalogenM $ liftF $ Subscribe (\_ -> es) identity
 
 -- | An alternative to `subscribe`, intended for subscriptions that unsubscribe
@@ -160,12 +161,12 @@ subscribe es = HalogenM $ liftF $ Subscribe (\_ -> es) identity
 -- | When a component is disposed of any active subscriptions will automatically
 -- | be stopped and no further subscriptions will be possible during
 -- | finalization.
-subscribe' :: forall state action slots output m. (SubscriptionId -> ES.EventSource m action) -> HalogenM state action slots output m Unit
+subscribe' :: forall surface state action slots output m. (SubscriptionId -> ES.EventSource m action) -> HalogenM surface state action slots output m Unit
 subscribe' esc = HalogenM $ liftF $ Subscribe esc (const unit)
 
 -- | Unsubscribes a component from an `EventSource`. If the subscription
 -- | associated with the ID has already ended this will have no effect.
-unsubscribe :: forall state action slots output m. SubscriptionId -> HalogenM state action slots output m Unit
+unsubscribe :: forall surface state action slots output m. SubscriptionId -> HalogenM surface state action slots output m Unit
 unsubscribe sid = HalogenM $ liftF $ Unsubscribe sid unit
 
 -- | The ID value associated with a forked process. Allows the fork to be killed
@@ -191,29 +192,29 @@ derive newtype instance ordForkId :: Ord ForkId
 -- | When a component is disposed of any active forks will automatically
 -- | be killed. New forks can be started during finalization but there will be
 -- | no means of killing them.
-fork :: forall state action slots output m. HalogenM state action slots output m Unit -> HalogenM state action slots output m ForkId
+fork :: forall surface state action slots output m. HalogenM surface state action slots output m Unit -> HalogenM surface state action slots output m ForkId
 fork hmu = HalogenM $ liftF $ Fork hmu identity
 
 -- | Kills a forked process if it is still running. Attempting to kill a forked
 -- | process that has already ended will have no effect.
-kill :: forall state action slots output m. ForkId -> HalogenM state action slots output m Unit
+kill :: forall surface state action slots output m. ForkId -> HalogenM surface state action slots output m Unit
 kill fid = HalogenM $ liftF $ Kill fid unit
 
 -- | Retrieves an `Element` value that is associated with a `Ref` in the
 -- | rendered output of a component. If there is no currently rendered value for
 -- | the requested ref this will return `Nothing`.
-getRef :: forall state action slots output m. RefLabel -> HalogenM state action slots output m (Maybe Element)
-getRef p = HalogenM $ liftF $ GetRef p identity
+getRef :: forall surface element state action slots output m. Surface surface element => RefLabel -> HalogenM surface state action slots output m (Maybe element)
+getRef p = HalogenM $ liftF $ GetRef p (map Surface.unbox)
 
 imapState
-  :: forall state state' action slots output m
+  :: forall surface state state' action slots output m
    . (state -> state')
   -> (state' -> state)
-  -> HalogenM state action slots output m
-  ~> HalogenM state' action slots output m
+  -> HalogenM surface state action slots output m
+  ~> HalogenM surface state' action slots output m
 imapState f f' (HalogenM h) = HalogenM (hoistFree go h)
   where
-  go :: HalogenF state action slots output m ~> HalogenF state' action slots output m
+  go :: HalogenF surface state action slots output m ~> HalogenF surface state' action slots output m
   go = case _ of
     State fs -> State (map f <<< fs <<< f')
     Subscribe fes k -> Subscribe fes k
@@ -227,14 +228,14 @@ imapState f f' (HalogenM h) = HalogenM (hoistFree go h)
     GetRef p k -> GetRef p k
 
 mapAction
-  :: forall state action action' slots output m
+  :: forall surface state action action' slots output m
    . Functor m
   => (action -> action')
-  -> HalogenM state action slots output m
-  ~> HalogenM state action' slots output m
+  -> HalogenM surface state action slots output m
+  ~> HalogenM surface state action' slots output m
 mapAction f (HalogenM h) = HalogenM (hoistFree go h)
   where
-  go :: HalogenF state action slots output m ~> HalogenF state action' slots output m
+  go :: HalogenF surface state action slots output m ~> HalogenF surface state action' slots output m
   go = case _ of
     State fs -> State fs
     Subscribe fes k -> Subscribe (map f <<< fes) k
@@ -248,13 +249,13 @@ mapAction f (HalogenM h) = HalogenM (hoistFree go h)
     GetRef p k -> GetRef p k
 
 mapOutput
-  :: forall state action slots output output' m
+  :: forall surface state action slots output output' m
    . (output -> output')
-  -> HalogenM state action slots output m
-  ~> HalogenM state action slots output' m
+  -> HalogenM surface state action slots output m
+  ~> HalogenM surface state action slots output' m
 mapOutput f (HalogenM h) = HalogenM (hoistFree go h)
   where
-  go :: HalogenF state action slots output m ~> HalogenF state action slots output' m
+  go :: HalogenF surface state action slots output m ~> HalogenF surface state action slots output' m
   go = case _ of
     State fs -> State fs
     Subscribe fes k -> Subscribe fes k
@@ -268,14 +269,14 @@ mapOutput f (HalogenM h) = HalogenM (hoistFree go h)
     GetRef p k -> GetRef p k
 
 hoist
-  :: forall state action slots output m m'
+  :: forall surface state action slots output m m'
    . Functor m'
   => (m ~> m')
-  -> HalogenM state action slots output m
-  ~> HalogenM state action slots output m'
+  -> HalogenM surface state action slots output m
+  ~> HalogenM surface state action slots output m'
 hoist nat (HalogenM fa) = HalogenM (hoistFree go fa)
   where
-  go :: HalogenF state action slots output m ~> HalogenF state action slots output m'
+  go :: HalogenF surface state action slots output m ~> HalogenF surface state action slots output m'
   go = case _ of
     State f -> State f
     Subscribe fes k -> Subscribe (ES.hoist nat <<< fes) k

--- a/src/Halogen/Query/Input.purs
+++ b/src/Halogen/Query/Input.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
-import Web.DOM (Element)
+import Halogen.Surface (SurfaceElement)
 
 newtype RefLabel = RefLabel String
 
@@ -12,8 +12,8 @@ derive instance newtypeRefLabel :: Newtype RefLabel _
 derive newtype instance eqRefLabel :: Eq RefLabel
 derive newtype instance ordRefLabel :: Ord RefLabel
 
-data Input action
-  = RefUpdate RefLabel (Maybe Element)
+data Input surface action
+  = RefUpdate RefLabel (Maybe (SurfaceElement surface))
   | Action action
 
-derive instance functorInput :: Functor Input
+derive instance functorInput :: Functor (Input surface)

--- a/src/Halogen/Surface.purs
+++ b/src/Halogen/Surface.purs
@@ -1,0 +1,13 @@
+module Halogen.Surface where
+
+import Unsafe.Coerce (unsafeCoerce)
+
+class Surface (s :: Type -> Type -> Type) e | s -> e
+
+foreign import data SurfaceElement :: (Type -> Type -> Type) -> Type
+
+box ∷ ∀ s e. Surface s e => e -> SurfaceElement s
+box = unsafeCoerce
+
+unbox ∷ ∀ s e. Surface s e => SurfaceElement s -> e
+unbox = unsafeCoerce

--- a/src/Halogen/VDom/Driver.purs
+++ b/src/Halogen/VDom/Driver.purs
@@ -35,7 +35,7 @@ import Web.HTML.HTMLElement as HTMLElement
 import Web.HTML.Window (document) as DOM
 
 type VHTML action slots =
-  V.VDom (Array (Prop (Input action))) (ComponentSlot HTML slots Aff action)
+  V.VDom (Array (Prop (Input HTML action))) (ComponentSlot HTML slots Aff action)
 
 type ChildRenderer action slots
   = ComponentSlotBox HTML slots Aff action -> Effect (RenderStateX RenderState)
@@ -55,11 +55,11 @@ type WidgetState slots action =
 
 mkSpec
   :: forall action slots
-   . (Input action -> Effect Unit)
+   . (Input HTML action -> Effect Unit)
   -> Ref (ChildRenderer action slots)
   -> DOM.Document
   -> V.VDomSpec
-      (Array (VP.Prop (Input action)))
+      (Array (VP.Prop (Input HTML action)))
       (ComponentSlot HTML slots Aff action)
 mkSpec handler renderChildRef document =
   V.VDomSpec { buildWidget, buildAttributes, document }
@@ -67,12 +67,12 @@ mkSpec handler renderChildRef document =
 
   buildAttributes
     :: DOM.Element
-    -> V.Machine (Array (VP.Prop (Input action))) Unit
+    -> V.Machine (Array (VP.Prop (Input HTML action))) Unit
   buildAttributes = VP.buildProp handler
 
   buildWidget
     :: V.VDomSpec
-          (Array (VP.Prop (Input action)))
+          (Array (VP.Prop (Input HTML action)))
           (ComponentSlot HTML slots Aff action)
     -> V.Machine
           (ComponentSlot HTML slots Aff action)
@@ -150,7 +150,7 @@ renderSpec document container =
 
   render
     :: forall state action slots output
-     . (Input action -> Effect Unit)
+     . (Input HTML action -> Effect Unit)
     -> (ComponentSlotBox HTML slots Aff action -> Effect (RenderStateX RenderState))
     -> HTML (ComponentSlot HTML slots Aff action) action
     -> Maybe (RenderState state action slots output)

--- a/test/Test/Component/ForkTest.purs
+++ b/test/Test/Component/ForkTest.purs
@@ -33,7 +33,7 @@ component =
     , eval: H.mkEval $ H.defaultEval { handleQuery = handleQuery }
     }
 
-handleQuery :: forall a. Query a -> H.HalogenM State (Query Unit) () Message Aff (Maybe a)
+handleQuery :: forall a. Query a -> H.HalogenM TD.TestRenderProduct State (Query Unit) () Message Aff (Maybe a)
 handleQuery = case _ of
   StartFork a -> do
     let


### PR DESCRIPTION
This means `HalogenF`, etc. no longer has HTML specific things lurking in it at all.

Plus, @thomashoneyman and I have been discussing adding a "portal" thing to `ComponentSlot`, and that would involve needing to provide an element appropriate to the surface type too, and I didn't really want to hard code `Element` in there as well, given it already had `surface` as part of the type.