### PR TITLE
Update README link for Real World Halogen

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Halogen 5 is fully usable in its current state and is actively being used in pro
 - The [examples](examples/)
 - Reading doc comments in the source
 - Jordan Martinez's [Learn Halogen](https://github.com/jordanmartinez/learn-halogen)
-- Thomas Honeyman's [Real World Halogen (branch/PR for v5)](https://github.com/thomashoneyman/purescript-halogen-realworld/pull/26)
+- Thomas Honeyman's [Real World Halogen](https://github.com/thomashoneyman/purescript-halogen-realworld)
 
 ## Installation
 


### PR DESCRIPTION
Real World Halogen's master branch is now on Halogen 5. I've updated the link here so that it no longer points to the pull request. 