### PR TITLE
Use `tell` or `request` directly to raise queries

### DIFF
--- a/examples/ace/src/Container.purs
+++ b/examples/ace/src/Container.purs
@@ -58,7 +58,7 @@ render { text: text } =
 handleAction :: forall o m. MonadAff m => Action -> H.HalogenM State Action ChildSlots o m Unit
 handleAction = case _ of
   ClearText ->
-    void $ H.query _ace unit $ H.tell (AceComponent.ChangeText "")
+    H.tell _ace unit (AceComponent.ChangeText "")
   HandleAceUpdate msg ->
     handleAceOuput msg
 

--- a/examples/components-multitype/src/Container.purs
+++ b/examples/components-multitype/src/Container.purs
@@ -73,7 +73,7 @@ render state = HH.div_
 handleAction :: forall o m. Action -> H.HalogenM State Action ChildSlots o m Unit
 handleAction = case _ of
   ReadStates -> do
-    a <- H.query _a unit (H.request CA.IsOn)
-    b <- H.query _b unit (H.request CB.GetCount)
-    c <- H.query _c unit (H.request CC.GetValue)
+    a <- H.request _a unit CA.IsOn
+    b <- H.request _b unit CB.GetCount
+    c <- H.request _c unit CC.GetValue
     H.put { a, b, c }

--- a/examples/components/src/Container.purs
+++ b/examples/components/src/Container.purs
@@ -61,5 +61,5 @@ handleAction = case _ of
   HandleButton (Button.Toggled _) -> do
     H.modify_ (\st -> st { toggleCount = st.toggleCount + 1 })
   CheckButtonState -> do
-    buttonState <- H.query _button unit $ H.request Button.IsOn
+    buttonState <- H.request _button unit Button.IsOn
     H.modify_ (_ { buttonState = buttonState })

--- a/examples/driver-io/src/Main.purs
+++ b/examples/driver-io/src/Main.purs
@@ -21,10 +21,10 @@ main = HA.runHalogenAff do
     liftEffect $ log $ "Button was internally toggled to: " <> show newState
     pure Nothing
 
-  state0 <- io.query $ H.request B.IsOn
+  state0 <- io.query $ H.mkRequest B.IsOn
   liftEffect $ log $ "The button state is currently: " <> show state0
 
-  void $ io.query $ H.tell (B.SetState true)
+  void $ io.query $ H.mkTell (B.SetState true)
 
-  state1 <- io.query $ H.request B.IsOn
+  state1 <- io.query $ H.mkRequest B.IsOn
   liftEffect $ log $ "The button state is now: " <> show state1

--- a/examples/driver-routing/src/Main.purs
+++ b/examples/driver-routing/src/Main.purs
@@ -25,6 +25,6 @@ main = HA.runHalogenAff do
   liftEffect do
     listener <- DOM.eventListener $ HCE.fromEvent >>> traverse_ \event -> do
       let hash = Str.drop 1 $ Str.dropWhile (_ /= '#') $ HCE.newURL event
-      launchAff_ $ io.query $ H.tell $ RouteLog.ChangeRoute hash
+      launchAff_ $ io.query $ H.mkTell $ RouteLog.ChangeRoute hash
 
     DOM.addEventListener HCET.hashchange listener false <<< Window.toEventTarget =<< DOM.window

--- a/examples/driver-websockets/src/Main.purs
+++ b/examples/driver-websockets/src/Main.purs
@@ -44,7 +44,7 @@ wsProducer socket = CRA.produce \emitter -> do
 -- producer.
 wsConsumer :: (forall a. Log.Query a -> Aff (Maybe a)) -> CR.Consumer String Aff Unit
 wsConsumer query = CR.consumer \msg -> do
-  void $ query $ H.tell $ Log.ReceiveMessage msg
+  void $ query $ H.mkTell $ Log.ReceiveMessage msg
   pure Nothing
 
 -- A handler for messages from our component IO that sends them to the server

--- a/examples/higher-order-components/src/Harness.purs
+++ b/examples/higher-order-components/src/Harness.purs
@@ -64,7 +64,7 @@ panelComponent = Panel.component Button.component
 handleAction :: forall o m. Action -> H.HalogenM State Action ChildSlots o m Unit
 handleAction = case _ of
   CheckButtonState -> do
-    buttonCheckState <- H.query _panel unit $ H.request (Panel.QueryInner <<< Button.IsOn)
+    buttonCheckState <- H.request _panel unit (Panel.QueryInner <<< Button.IsOn)
     H.modify_ (_ { buttonCheckState = buttonCheckState })
   HandlePanelMessage msg ->
     handlePanelMessage msg

--- a/src/Halogen.purs
+++ b/src/Halogen.purs
@@ -21,7 +21,7 @@ import Halogen.Component (Component, ComponentSpec, ComponentSlot, ComponentSlot
 import Halogen.Data.Slot (Slot)
 import Halogen.HTML (ComponentHTML)
 import Halogen.HTML.Core (AttrName(..), ClassName(..), Namespace(..), PropName(..), ElemName(..))
-import Halogen.Query (ForkId, HalogenF(..), HalogenM(..), HalogenQ(..), RefLabel(..), Request, SubscriptionId, Tell, fork, get, getHTMLElementRef, getRef, gets, kill, lift, liftAff, liftEffect, modify, modify_, put, query, queryAll, raise, request, subscribe, subscribe', tell, unsubscribe)
+import Halogen.Query (ForkId, HalogenF(..), HalogenM(..), HalogenQ(..), RefLabel(..), Request, SubscriptionId, Tell, fork, get, getHTMLElementRef, getRef, gets, kill, lift, liftAff, liftEffect, mkRequest, mkTell, modify, modify_, put, query, queryAll, raise, request, subscribe, subscribe', tell, unsubscribe)
 
 -- | A record produced when the root component in a Halogen UI has been run.
 -- |

--- a/test/Test/Component/ForkTest.purs
+++ b/test/Test/Component/ForkTest.purs
@@ -62,9 +62,9 @@ testForkKill = do
     H.liftEffect $ Ref.modify_ (msg : _) logRef
     pure Nothing
 
-  _ <- io.query (H.tell StartFork)
+  _ <- io.query (H.mkTell StartFork)
   Aff.delay (Aff.Milliseconds 350.0)
-  _ <- io.query (H.tell KillFork)
+  _ <- io.query (H.mkTell KillFork)
 
   -- TODO: revisit this: why do we need to wait to receive `raise`d messages
   -- from the component, if the `raise` occurs after any bind?
@@ -94,7 +94,7 @@ testFinalize = do
     H.liftEffect $ Ref.modify_ (msg : _) logRef
     pure Nothing
 
-  _ <- io.query (H.tell StartFork)
+  _ <- io.query (H.mkTell StartFork)
   io.dispose
   Aff.delay (Aff.Milliseconds 350.0)
 

--- a/test/Test/DocExamples/Action.purs
+++ b/test/Test/DocExamples/Action.purs
@@ -9,4 +9,4 @@ import Halogen as H
 data Query a = Tick a
 
 sendTick :: forall o. H.HalogenIO Query o Aff -> Aff (Maybe Unit)
-sendTick io = io.query (H.tell Tick)
+sendTick io = io.query (H.mkTell Tick)

--- a/test/Test/DocExamples/Request.purs
+++ b/test/Test/DocExamples/Request.purs
@@ -7,4 +7,4 @@ import Halogen as H
 data Query a = GetTickCount (Int -> a)
 
 getTickCount :: forall o. H.HalogenIO Query o Aff -> Aff (Maybe Int)
-getTickCount app = app.query (H.request GetTickCount)
+getTickCount app = app.query (H.mkRequest GetTickCount)


### PR DESCRIPTION
Resolves #611 

Unfortunately had to keep the old functions as `mkTell` and `mkRequest` though, for use with the top level driver `query`. I suppose another option would be to replace that with separate `tell` and `request`
properties on `HalogenIO` too.