### PR TITLE
Read selfRef in finalize

### DIFF
--- a/src/Halogen/Aff/Driver.purs
+++ b/src/Halogen/Aff/Driver.purs
@@ -255,7 +255,8 @@ runUI renderSpec component i = do
     -> DriverStateX r f' o'
     -> Effect Unit
   finalize lchs = do
-    unDriverStateX \st -> do
+    unDriverStateX \{ selfRef } -> do
+      (DriverState st) <- liftEffect $ Ref.read selfRef
       cleanupSubscriptionsAndForks (DriverState st)
       let f = Eval.evalM render st.selfRef (st.component.eval (HQ.Finalize unit))
       lchs # Ref.modify_ \handlers ->

--- a/src/Halogen/Query/HalogenM.purs
+++ b/src/Halogen/Query/HalogenM.purs
@@ -243,7 +243,7 @@ imapState
   -> HalogenM state' action slots output m a
 imapState f f' = mapState (\s' -> Tuple (f' s') f)
 
-mapState 
+mapState
   :: forall state state' action slots output m a
    . (state' -> Tuple state (state -> state'))
   -> HalogenM state action slots output m a
@@ -271,9 +271,9 @@ hoist
   => (m ~> m')
   -> HalogenM state action slots output m a
   -> HalogenM state action slots output m' a
-hoist = mapHalogen identityLens identity identity 
+hoist = mapHalogen identityLens identity identity
 
-mapHalogen 
+mapHalogen
   :: forall state state' action action' slots output output' m m' a
    . (state' -> Tuple state (state -> state'))
   -> (action -> action')
@@ -285,7 +285,7 @@ mapHalogen lens fa fo nat (HalogenM alg) = HalogenM (hoistFree go alg)
   where
   go :: HalogenF state action slots output m ~> HalogenF state' action' slots output' m'
   go = case _ of
-    State f -> State (\s' -> let Tuple s g = lens s' in (map g (f s) ))
+    State f -> State (\s' -> let Tuple s g = lens s' in (map g (f s)))
     Subscribe fes k -> Subscribe (map fa <<< fes) k
     Unsubscribe sid a -> Unsubscribe sid a
     Lift q -> Lift (nat q)
@@ -297,5 +297,5 @@ mapHalogen lens fa fo nat (HalogenM alg) = HalogenM (hoistFree go alg)
     Kill fid a -> Kill fid a
     GetRef p k -> GetRef p k
 
-identityLens :: forall s . s -> Tuple s (s -> s)
+identityLens :: forall s. s -> Tuple s (s -> s)
 identityLens s = Tuple s identity


### PR DESCRIPTION
This changes the implementation of `finalize` in `runUI` to read the `selfRef` similar to what's being done in `dispose` for the `rendering` field.

This fixes a bug wherein finalizers from newly-rendered slots aren't run when `dispose` is called. For example, if you have a router root component, the current `dispose` would only run finalizers for the initial page, and not respond to changes in the router component.

This is needed because the following line in `render` effectively makes it so that the `DriverState` bound in the `dispose` for `HalogenIO` is older than the one that's currently being used in the driver.

```hs
    flip Ref.modify_ ds.selfRef $ mapDriverState \ds' ->
      ds' { rendering = Just rendering, children = children }
```